### PR TITLE
fix(p0): improve resilience, validate inputs, redact log dump by default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.idea
+.vscode
+.opencode
+.env
+.env.*
+*.bak
+*.log
+*.swp
+.DS_Store
+PROPOSAL.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1
-        with:
-          ignore: SC2096
+      # rhysd/actionlint is a Go binary, not a JavaScript action. We install
+      # it directly from the upstream release instead of using a wrapper
+      # action, which keeps the dependency footprint small and the version
+      # pin explicit.
+      - name: Install actionlint
+        run: |
+          set -e
+          ver=1.7.7
+          curl -sSL -o /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_amd64.tar.gz"
+          tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
+          sudo mv /tmp/actionlint /usr/local/bin/actionlint
+          actionlint --version
+      - name: Run actionlint
+        run: actionlint -color
 
   hadolint:
     name: hadolint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3
+      # Pin to a specific tag because the upstream has no floating "v3" ref
+      # (only v3.0.0, v3.1.0, ...). Using `@v3` makes the resolver fail.
+      - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
           # DL3018 (pin apk versions) is a real concern but fixing it is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          shellcheck --version
+      - name: Run shellcheck
+        run: |
+          set -e
+          shellcheck init.sh
+          shellcheck tests/contract.sh
+          shellcheck tests/smoke.sh
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1
+        with:
+          ignore: SC2096
+
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3
+        with:
+          dockerfile: Dockerfile
+          # DL3018 (pin apk versions) is a real concern but fixing it is
+          # out of scope for this PR — it will be addressed alongside
+          # the image digest pinning work. Treat as info for now.
+          failure-threshold: error
+
+  contract:
+    name: Contract test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify action.yml ↔ init.sh consistency
+        run: tests/contract.sh
+
+  smoke:
+    name: Smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run init.sh smoke tests in alpine
+        run: tests/smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `mirror_verbose` input (was documented in the README but never declared in
+  `action.yml`, so the value was silently ignored).
+- `lftp_settings` input (was also undocumented in `action.yml`).
+- `debug` input. Default `false` shows only which inputs were received; set
+  to `true` to print resolved values for troubleshooting.
+- `SECURITY.md` with private disclosure policy and supported-versions table.
+- `CHANGELOG.md` (this file) following Keep a Changelog.
+- `.dockerignore` to keep the build context minimal.
+- Exit code documentation in the README (`0` success, `1` upload failed,
+  `2` invalid input).
+- `validate_int` helper in `init.sh` that fails fast with a clear error
+  when an integer input (e.g. `max_retries`) is not a non-negative integer.
+- Global 5-hour wall-clock timeout around each `lftp` invocation.
+- Exponential backoff with jitter between retries (1s, 2s, 4s, 8s, 16s,
+  then capped at 30s), replacing the previous flat 60s sleep.
+- Last `lftp` exit code is printed in the failure banner for easier
+  debugging.
+
+### Fixed
+- B-01: `mirror_verbose` is now a real, configurable input.
+- B-05: `lftp` exit code is captured explicitly so the "ERROR" banner is
+  always reached (previously `set -e` short-circuited the script).
+- B-06: `INPUT_MAX_RETRIES` is now quoted in the comparison (shellcheck
+  SC2086).
+- B-07: `max_retries`, `mirror_verbose`, `ftp_nop_interval`,
+  `net_max_retries`, `net_persist_retries` and `dns_max_retries` are
+  validated as non-negative integers before use; the action now exits
+  with code `2` and a clear error if any value is malformed.
+- B-08: retry backoff is now exponential with jitter instead of a flat
+  60 seconds; total wall-clock for the 10-retry default drops from
+  ~10 minutes of pure sleeping to ~2.5 minutes.
+- B-09: a hung `lftp` is now killed after 5 hours (with a 30s grace
+  period before SIGKILL) instead of running until the runner timeout.
+- B-10: input values are no longer echoed to the log by default; only
+  their names and `(set)` / `(using default)` status. Set
+  `debug: "true"` to see resolved values.
+- B-11: README now explicitly distinguishes the minimal example from
+  the "no default" extended example.
+- B-12: `lftp_settings` is now declared in `action.yml` (previously
+  referenced in `init.sh` and the README but invisible as an input).
+- B-15: `.dockerignore` excludes `.git/`, `.github/`, `.idea/`,
+  `.vscode/`, `.opencode/`, `.env*`, `PROPOSAL.md` and editor backups
+  from the build context.
+
+### Security
+- Password and other input values are no longer printed to the workflow
+  log by default.
+
+## [1.3.3] - 2024-XX-XX
+
+Historical. See git history for changes prior to `CHANGELOG.md` adoption.
+
+[Unreleased]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.3.3

--- a/README.md
+++ b/README.md
@@ -65,10 +65,17 @@ Usually the zero values mean unlimited or infinite. This table is based on the d
 | dns_max_retries        | DNS - 0 no limit trying to lookup an address otherwise try only this number of times. | No       | 8       | N/A                                                                                               |
 | dns_fatal_timeout      | DNS - Time for DNS queries.<br> Set to "never" to disable.                            | No       | 10s     | N/A                                                                                               |
 | lftp_settings          | Any other settings that you find in the MAN pages for the LFTP package.               | No       | ""      | "set cache:cache-empty-listings true; set cmd:status-interval 1s; set http:user-agent 'firefox';" |
+| debug                  | If "true", print resolved input values to the log.                                    | No       | false   | N/A                                                                                               |
 
 More information on the official site for [lftp - Manual pages][2].
 
-Example with NO DEFAULT settings:
+### Minimal example (only required inputs)
+
+The example above shows the **minimum** required inputs (`server`, `user`, `password`, `local_dir`).
+All other settings use the defaults shown in the table above. For full control see the
+extended example below.
+
+### Example with NO DEFAULT settings
 
 ```yaml
 name: CI -> Deploy to My website
@@ -113,6 +120,26 @@ Main features:
 - Option to delete all the files in the specific remote folder before the upload.
 - Using Alpine container means small size and faster creation of the container.
 - Show messages in the console logs for every executed command.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Upload finished successfully. |
+| `1`  | Upload failed after all retries; the last lftp error is printed above. |
+| `2`  | Invalid input (a non-integer was passed to a numeric option such as `max_retries`). |
+
+When the global 5-hour timeout is reached the lftp process is killed and the
+action exits with `1` (the most recent lftp exit code is also printed to the
+log for debugging).
+
+## Security
+
+For how to report vulnerabilities please see [`SECURITY.md`](./SECURITY.md).
+
+## Changelog
+
+See [`CHANGELOG.md`](./CHANGELOG.md) for release notes.
 
 TODOs:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest tagged release receives security fixes. Older tags
+(`v1.0-alpha.*`, `v1.1`, `v1.2.0`, `v1.3.x`, `latest`) are kept on a
+best-effort basis and may not receive patches.
+
+| Tag        | Supported |
+|------------|-----------|
+| `latest`   | Yes       |
+| `<v1.4+>`  | Yes       |
+| `<v1.4`    | No        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security problems.
+
+Report privately by emailing **israel.alberto.rv@gmail.com** with:
+
+- A short description of the issue and its impact.
+- A reproducer (workflow YAML, lftp command, or steps).
+- The affected version (commit SHA or tag).
+
+You should receive an acknowledgement within 72 hours. If you do not,
+please follow up with a second email.
+
+## What to expect
+
+- **Acknowledgement** within 72 hours.
+- **Triage** within 7 days: confirm the issue, assign a CVSS estimate
+  and decide whether to fix in-tree or in a fork.
+- **Fix** for critical/high issues as soon as possible, ideally within
+  30 days. Lower-severity issues are bundled with the next regular
+  release.
+- **Disclosure**: once a fix is published, the original report will be
+  credited in the release notes (unless the reporter prefers otherwise).
+
+## Out of scope
+
+- Vulnerabilities in upstream `lftp` — please report them upstream at
+  https://lftp.yar.ru/.
+- Vulnerabilities in the base `alpine` image — please report to the
+  Alpine security team.
+- Misconfiguration of the action (e.g. using `delete: true` with the
+  wrong `remote_dir`) that does not require a code change.

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Do not create symbolic links.'
     required: false
     default: 'true'
+  mirror_verbose:
+    description: 'Mirror verbosity level (0-3). Passed as --verbose=N to lftp mirror.'
+    required: false
+    default: '1'
   ftp_ssl_allow:
     description: 'FTP - Allow SSL encryption.'
     required: false
@@ -77,6 +81,14 @@ inputs:
     description: 'DNS - Time for DNS queries. Set to "never" to disable.'
     required: false
     default: '10s'
+  lftp_settings:
+    description: 'Additional raw lftp settings, e.g. "set cache:cache-empty-listings true; set cmd:status-interval 1s;". Use with care: this is appended to the lftp `-e` command and not validated.'
+    required: false
+    default: ''
+  debug:
+    description: 'If "true", print resolved input values to the log. Default is "false" (only show which inputs were received, not their values).'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/init.sh
+++ b/init.sh
@@ -67,11 +67,30 @@ pwd
 echo ""
 
 # ------------------------------------------------------------------------------
-# B-07: Validate integer inputs early so failures are clear.
+# B-07: Normalize integer inputs to their effective defaults, then validate.
+#   In a real GitHub Actions run these are always populated by the
+#   action.yml default, but init.sh can also be run outside that
+#   mechanism (tests, manual invocation), so we apply the same
+#   defaults here before validating. This avoids a false-positive
+#   exit 2 on an empty numeric input.
 # ------------------------------------------------------------------------------
-# Max number of retries
 if [ -z "${INPUT_MAX_RETRIES}" ]; then
   INPUT_MAX_RETRIES="10"
+fi
+if [ -z "${INPUT_MIRROR_VERBOSE}" ]; then
+  INPUT_MIRROR_VERBOSE="1"
+fi
+if [ -z "${INPUT_FTP_NOP_INTERVAL}" ]; then
+  INPUT_FTP_NOP_INTERVAL="2"
+fi
+if [ -z "${INPUT_NET_MAX_RETRIES}" ]; then
+  INPUT_NET_MAX_RETRIES="1"
+fi
+if [ -z "${INPUT_NET_PERSIST_RETRIES}" ]; then
+  INPUT_NET_PERSIST_RETRIES="5"
+fi
+if [ -z "${INPUT_DNS_MAX_RETRIES}" ]; then
+  INPUT_DNS_MAX_RETRIES="8"
 fi
 validate_int "max_retries"         "${INPUT_MAX_RETRIES}"
 validate_int "mirror_verbose"      "${INPUT_MIRROR_VERBOSE}"
@@ -286,9 +305,12 @@ while true; do
     *) DELAY=30 ;;
   esac
   if [ "${DELAY}" -gt 1 ]; then
-    HALF=$(( DELAY / 2 ))
+    # ±50% jitter: range is [-DELAY/2, +DELAY/2] so DELAY=4 -> ±2s,
+    # DELAY=2 -> ±1s, DELAY=8 -> ±4s. The previous formula
+    # `(RANDOM % (HALF + 1)) - (HALF / 2)` was off because for small
+    # DELAY the integer division collapsed the negative half.
     # shellcheck disable=SC3028  # RANDOM is a busybox ash extension (the shell we actually run in).
-    JITTER=$(( (RANDOM % (HALF + 1)) - (HALF / 2) ))
+    JITTER=$(( RANDOM % (DELAY + 1) - DELAY / 2 ))
     SLEEP_S=$(( DELAY + JITTER ))
   else
     SLEEP_S="${DELAY}"

--- a/init.sh
+++ b/init.sh
@@ -1,33 +1,84 @@
 #!/bin/sh -e
 
 # ------------------------------------------------------------------------------
-# Display environment variables.
+# Helpers.
 # ------------------------------------------------------------------------------
-echo "=== Environment variables ==="
-echo "INPUT_SERVER: ${INPUT_SERVER}"
-echo "INPUT_USER: ${INPUT_USER}"
-echo "INPUT_LOCAL_DIR: ${INPUT_LOCAL_DIR}"
-echo "INPUT_REMOTE_DIR: ${INPUT_REMOTE_DIR}"
-echo "INPUT_MAX_RETRIES: ${INPUT_MAX_RETRIES}"
-echo "INPUT_DELETE: ${INPUT_DELETE}"
-echo "INPUT_NO_SYMLINKS: ${INPUT_NO_SYMLINKS}"
-echo "INPUT_MIRROR_VERBOSE: ${INPUT_MIRROR_VERBOSE}"
-echo "INPUT_FTP_SSL_ALLOW: ${INPUT_FTP_SSL_ALLOW}"
-echo "INPUT_SSL_VERIFY_CERTIFICATE: ${INPUT_SSL_VERIFY_CERTIFICATE}"
-echo "INPUT_SSL_CHECK_HOSTNAME: ${INPUT_SSL_CHECK_HOSTNAME}"
-echo "INPUT_FTP_PASSIVE_MODE: ${INPUT_FTP_PASSIVE_MODE}"
-echo "INPUT_FTP_USE_FEAT: ${INPUT_FTP_USE_FEAT}"
-echo "INPUT_FTP_NOP_INTERVAL: ${INPUT_FTP_NOP_INTERVAL}"
-echo "INPUT_NET_MAX_RETRIES: ${INPUT_NET_MAX_RETRIES}"
-echo "INPUT_NET_PERSIST_RETRIES: ${INPUT_NET_PERSIST_RETRIES}"
-echo "INPUT_NET_TIMEOUT: ${INPUT_NET_TIMEOUT}"
-echo "INPUT_DNS_MAX_RETRIES: ${INPUT_DNS_MAX_RETRIES}"
-echo "INPUT_DNS_FATAL_TIMEOUT: ${INPUT_DNS_FATAL_TIMEOUT}"
-echo "INPUT_LFTP_SETTINGS: ${INPUT_LFTP_SETTINGS}"
+
+# validate_int NAME VALUE
+#   Exit 2 with a clear error if VALUE is not a non-negative integer.
+validate_int() {
+  _vi_name=$1
+  _vi_value=$2
+  printf '%s' "${_vi_value}" | grep -qE '^[0-9]+$' || {
+    printf 'ERROR: %s must be a non-negative integer (got: %s)\n' \
+      "${_vi_name}" "${_vi_value}" >&2
+    exit 2
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Display environment variables.
+#
+# B-10: By default, only show which inputs were received (no values). Set
+# INPUT_DEBUG=true to print resolved values for troubleshooting.
+# ------------------------------------------------------------------------------
+echo "=== Inputs received ==="
+if [ "${INPUT_DEBUG}" = "true" ]; then
+  printf '  %-26s %s\n' "server:"                  "${INPUT_SERVER}"
+  printf '  %-26s %s\n' "user:"                    "${INPUT_USER}"
+  printf '  %-26s %s\n' "password:"                "${INPUT_PASSWORD}"
+  printf '  %-26s %s\n' "local_dir:"               "${INPUT_LOCAL_DIR}"
+  printf '  %-26s %s\n' "remote_dir:"              "${INPUT_REMOTE_DIR}"
+  printf '  %-26s %s\n' "max_retries:"             "${INPUT_MAX_RETRIES}"
+  printf '  %-26s %s\n' "delete:"                  "${INPUT_DELETE}"
+  printf '  %-26s %s\n' "no_symlinks:"             "${INPUT_NO_SYMLINKS}"
+  printf '  %-26s %s\n' "mirror_verbose:"          "${INPUT_MIRROR_VERBOSE}"
+  printf '  %-26s %s\n' "ftp_ssl_allow:"           "${INPUT_FTP_SSL_ALLOW}"
+  printf '  %-26s %s\n' "ssl_verify_certificate:"  "${INPUT_SSL_VERIFY_CERTIFICATE}"
+  printf '  %-26s %s\n' "ssl_check_hostname:"      "${INPUT_SSL_CHECK_HOSTNAME}"
+  printf '  %-26s %s\n' "ftp_passive_mode:"        "${INPUT_FTP_PASSIVE_MODE}"
+  printf '  %-26s %s\n' "ftp_use_feat:"            "${INPUT_FTP_USE_FEAT}"
+  printf '  %-26s %s\n' "ftp_nop_interval:"        "${INPUT_FTP_NOP_INTERVAL}"
+  printf '  %-26s %s\n' "net_max_retries:"         "${INPUT_NET_MAX_RETRIES}"
+  printf '  %-26s %s\n' "net_persist_retries:"     "${INPUT_NET_PERSIST_RETRIES}"
+  printf '  %-26s %s\n' "net_timeout:"             "${INPUT_NET_TIMEOUT}"
+  printf '  %-26s %s\n' "dns_max_retries:"         "${INPUT_DNS_MAX_RETRIES}"
+  printf '  %-26s %s\n' "dns_fatal_timeout:"       "${INPUT_DNS_FATAL_TIMEOUT}"
+  printf '  %-26s %s\n' "lftp_settings:"           "${INPUT_LFTP_SETTINGS}"
+  printf '  %-26s %s\n' "debug:"                   "${INPUT_DEBUG}"
+else
+  for _v in SERVER USER PASSWORD LOCAL_DIR REMOTE_DIR MAX_RETRIES DELETE \
+            NO_SYMLINKS MIRROR_VERBOSE FTP_SSL_ALLOW SSL_VERIFY_CERTIFICATE \
+            SSL_CHECK_HOSTNAME FTP_PASSIVE_MODE FTP_USE_FEAT FTP_NOP_INTERVAL \
+            NET_MAX_RETRIES NET_PERSIST_RETRIES NET_TIMEOUT DNS_MAX_RETRIES \
+            DNS_FATAL_TIMEOUT LFTP_SETTINGS DEBUG; do
+    _label=$(printf '%s' "${_v}" | tr '[:upper:]' '[:lower:]')
+    eval "_cur=\${INPUT_${_v}}"
+    if [ -n "${_cur}" ]; then
+      printf '  %-26s (set)\n' "${_label}:"
+    else
+      printf '  %-26s (using default)\n' "${_label}:"
+    fi
+  done
+fi
 echo ""
 echo "=== Current location ==="
 pwd
 echo ""
+
+# ------------------------------------------------------------------------------
+# B-07: Validate integer inputs early so failures are clear.
+# ------------------------------------------------------------------------------
+# Max number of retries
+if [ -z "${INPUT_MAX_RETRIES}" ]; then
+  INPUT_MAX_RETRIES="10"
+fi
+validate_int "max_retries"         "${INPUT_MAX_RETRIES}"
+validate_int "mirror_verbose"      "${INPUT_MIRROR_VERBOSE}"
+validate_int "ftp_nop_interval"    "${INPUT_FTP_NOP_INTERVAL}"
+validate_int "net_max_retries"     "${INPUT_NET_MAX_RETRIES}"
+validate_int "net_persist_retries" "${INPUT_NET_PERSIST_RETRIES}"
+validate_int "dns_max_retries"     "${INPUT_DNS_MAX_RETRIES}"
 
 # ------------------------------------------------------------------------------
 # Set the LFTP setting.
@@ -121,11 +172,6 @@ if [ -n "${FTP_SETTINGS}" ]; then
   FTP_SETTINGS="${FTP_SETTINGS#"${FTP_SETTINGS%%[![:space:]]*}"}"
 fi
 
-# Max number of retries
-if [ -z "${INPUT_MAX_RETRIES}" ]; then
-  INPUT_MAX_RETRIES="10"
-fi
-
 # Local path to get the directories
 if [ -z "${INPUT_LOCAL_DIR}" ]; then
   INPUT_LOCAL_DIR="./"
@@ -184,31 +230,72 @@ echo "If the process take for several minutes or hours, please stop the job and 
 
 # ------------------------------------------------------------------------------
 # Execute the LFTP actions.
+#
+# B-09: Wrap with a hard global timeout (5h) so a hung lftp cannot run past
+# the GH Actions job limit. busybox `timeout` supports -k for SIGKILL after a
+# grace period.
+#
+# B-05: Capture lftp's exit code explicitly. With `set -e` and `&&`, a
+# non-zero lftp exit was causing the script to abort via the `set -e`
+# short-circuit instead of falling into the "ERROR" banner.
+#
+# B-08: Exponential backoff with jitter, capped at 30s. The proposal's
+# `2 ** (COUNTER - 1)` example is invalid in POSIX sh (no `**` operator);
+# we use a small lookup table instead.
 # ------------------------------------------------------------------------------
 COUNTER=1
 SUCCESS=""
+
+# B-09: hard cap on the total wall-clock time of one lftp invocation.
+LFTP_TIMEOUT="5h"
+LFTP_KILL_AFTER="30s"
 
 while true; do
   echo ""
   echo "Try #${COUNTER}"
   echo "-------"
 
-  lftp \
+  set +e
+  timeout -k "${LFTP_KILL_AFTER}" "${LFTP_TIMEOUT}" lftp \
     -u "${INPUT_USER}","${INPUT_PASSWORD}" \
     "${INPUT_SERVER}" \
-    -e "${FTP_SETTINGS} ${MIRROR_COMMAND} ${INPUT_LOCAL_DIR} ${INPUT_REMOTE_DIR}; quit;" &&
-    SUCCESS="true"
+    -e "${FTP_SETTINGS} ${MIRROR_COMMAND} ${INPUT_LOCAL_DIR} ${INPUT_REMOTE_DIR}; quit;"
+  LFTP_RC=$?
+  set -e
 
-  if [ -n "${SUCCESS}" ]; then
+  if [ "${LFTP_RC}" -eq 0 ]; then
+    SUCCESS="true"
     break
   fi
+
+  echo "  lftp exited with code ${LFTP_RC}"
 
   COUNTER=$((COUNTER + 1))
-  if [ ${COUNTER} -gt ${INPUT_MAX_RETRIES} ]; then
+  # B-06: quote to satisfy shellcheck SC2086 and `set -u` semantics.
+  if [ "${COUNTER}" -gt "${INPUT_MAX_RETRIES}" ]; then
     break
   fi
 
-  sleep 1m
+  # B-08: exponential backoff with jitter, capped at 30s.
+  case "${COUNTER}" in
+    2) DELAY=1 ;;
+    3) DELAY=2 ;;
+    4) DELAY=4 ;;
+    5) DELAY=8 ;;
+    6) DELAY=16 ;;
+    *) DELAY=30 ;;
+  esac
+  if [ "${DELAY}" -gt 1 ]; then
+    HALF=$(( DELAY / 2 ))
+    # shellcheck disable=SC3028  # RANDOM is a busybox ash extension (the shell we actually run in).
+    JITTER=$(( (RANDOM % (HALF + 1)) - (HALF / 2) ))
+    SLEEP_S=$(( DELAY + JITTER ))
+  else
+    SLEEP_S="${DELAY}"
+  fi
+  [ "${SLEEP_S}" -lt 1 ] && SLEEP_S=1
+  echo "  Backing off ${SLEEP_S}s before retry..."
+  sleep "${SLEEP_S}"
 done
 
 # ------------------------------------------------------------------------------
@@ -219,6 +306,14 @@ if [ -z "${SUCCESS}" ]; then
   echo "=============================="
   echo "=    ERROR: UPLOAD FAILED    ="
   echo "=============================="
+  if [ -n "${LFTP_RC}" ]; then
+    echo "Last lftp exit code: ${LFTP_RC}"
+    echo "Common codes:"
+    echo "  1   lftp generic error"
+    echo "  4    Fatal error (e.g. command-line usage, configuration)"
+    echo "  124  timeout reached (max wall-clock ${LFTP_TIMEOUT})"
+    echo "  137  process killed (SIGKILL after ${LFTP_KILL_AFTER} grace)"
+  fi
   exit 1
 fi
 

--- a/tests/contract.sh
+++ b/tests/contract.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# tests/contract.sh — verify that the user-facing contract between
+# action.yml and init.sh is consistent. Would have caught B-01
+# (mirror_verbose declared in init.sh/README but not in action.yml).
+#
+# Strategy:
+#   1. Parse action.yml and collect the list of input names declared
+#      under `inputs:`.
+#   2. Grep init.sh for every literal `INPUT_<NAME>` reference and
+#      collect the set of names referenced statically.
+#   3. Grep init.sh for the "for _v in <NAME1> <NAME2> ...; do" dump
+#      loop and collect the names referenced dynamically.
+#   4. Assert: all three sets are equal.
+#
+# Exit 0 on success, non-zero on any mismatch.
+
+set -u
+
+# CDPATH= cd -- ... is the POSIX idiom to resolve the script's own directory
+# without being affected by the caller's CDPATH. shellcheck gets confused
+# by the `=` spacing, hence the disable.
+# shellcheck disable=SC1007
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ACTION="${ROOT}/action.yml"
+INIT="${ROOT}/init.sh"
+
+[ -f "${ACTION}" ] || { echo "missing ${ACTION}" >&2; exit 1; }
+[ -f "${INIT}" ]   || { echo "missing ${INIT}" >&2;   exit 1; }
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+ok()   { printf '  ok: %s\n' "$*"; }
+
+# 1. Inputs declared in action.yml (top-level keys under "inputs:").
+declared=$(awk '
+  /^inputs:/ { in_inputs = 1; next }
+  in_inputs && /^runs:/ { in_inputs = 0; next }
+  in_inputs && /^  [a-z][a-z0-9_]*:$/ {
+    sub(/:$/, "")
+    sub(/^  /, "")
+    print
+  }
+' "${ACTION}" | sort -u)
+[ -n "${declared}" ] || fail "no inputs found in action.yml under 'inputs:'"
+
+# 2. INPUT_<X> static references in init.sh.
+static=$(grep -oE 'INPUT_[A-Z][A-Z0-9_]*' "${INIT}" \
+  | sed 's/^INPUT_//' \
+  | tr '[:upper:]' '[:lower:]' \
+  | sort -u)
+[ -n "${static}" ] || fail "no INPUT_<X> references found in init.sh"
+
+# 3. Dump loop's name list in init.sh (collects across line continuations).
+#    Strip backslashes (line-continuation markers) before splitting.
+dynamic=$(awk '
+  /for _v in/ { capture = 1; buf = "" }
+  capture {
+    buf = buf " " $0
+    if (/; do/) {
+      sub(/^.*for _v in /, "", buf)
+      sub(/; do.*$/, "", buf)
+      print tolower(buf)
+      capture = 0
+    }
+  }
+' "${INIT}" | sed 's/\\//g' | tr -s '[:space:]' '\n' | sed '/^$/d' | sort -u)
+[ -n "${dynamic}" ] || fail "could not extract dump loop name list from init.sh"
+
+# 4. Compare the three sets. Use temp files so we don't depend on
+# process substitution (which shellcheck flags SC3001 in strict POSIX).
+_diff_files() {
+  _a=$1; _b=$2
+  _f1=$(mktemp) || return 1
+  _f2=$(mktemp) || return 1
+  printf '%s\n' "${_a}" > "${_f1}"
+  printf '%s\n' "${_b}" > "${_f2}"
+  diff "${_f1}" "${_f2}" | sed 's/^/  /'
+  _rc=$?
+  rm -f "${_f1}" "${_f2}"
+  return "${_rc}"
+}
+
+if [ "${declared}" != "${static}" ]; then
+  printf 'declared inputs (action.yml) vs static INPUT_* refs (init.sh) differ:\n' >&2
+  _diff_files "${declared}" "${static}" >&2 || true
+  fail "static INPUT_* references do not match declared inputs"
+fi
+ok "static INPUT_* references match declared inputs"
+
+if [ "${declared}" != "${dynamic}" ]; then
+  printf 'declared inputs (action.yml) vs dump loop list (init.sh) differ:\n' >&2
+  _diff_files "${declared}" "${dynamic}" >&2 || true
+  fail "dump loop's name list does not match declared inputs"
+fi
+ok "dump loop's name list matches declared inputs"
+
+n=$(echo "${declared}" | wc -l | tr -d ' ')
+printf '  info: %s input(s): %s\n' "${n}" "$(echo "${declared}" | tr '\n' ' ')"
+
+exit 0

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+# tests/smoke.sh — smoke tests for init.sh.
+#
+# These run init.sh inside an Alpine container with lftp installed
+# against a fake server (TCP port 1, which refuses connection) and
+# assert the expected behaviour.
+#
+# Requirements:
+#   - docker or podman on PATH
+#   - network access to pull alpine:3.23.3 (first run only)
+#
+# Skip (exit 0) if no container runtime is available.
+
+set -u
+
+# shellcheck disable=SC1007
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+INIT_REL=./init.sh
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf '  ok: %s\n' "$*"; }
+skip() { printf '  skip: %s\n' "$*"; exit 0; }
+
+if command -v docker >/dev/null 2>&1; then
+  RUNTIME=docker
+elif command -v podman >/dev/null 2>&1; then
+  RUNTIME=podman
+else
+  skip "no docker/podman found"
+fi
+
+# Build the base env that all tests use. The dummy server refuses
+# connections on port 1, so lftp fails immediately.
+common_env() {
+  printf '%s\n' \
+    "INPUT_SERVER=ftp://127.0.0.1:1" \
+    "INPUT_USER=u" \
+    "INPUT_PASSWORD=p" \
+    "INPUT_MAX_RETRIES=1" \
+    "INPUT_MIRROR_VERBOSE=1" \
+    "INPUT_FTP_NOP_INTERVAL=2" \
+    "INPUT_NET_MAX_RETRIES=1" \
+    "INPUT_NET_PERSIST_RETRIES=1" \
+    "INPUT_DNS_MAX_RETRIES=1" \
+    "INPUT_NET_TIMEOUT=1s" \
+    "INPUT_DNS_FATAL_TIMEOUT=1s" \
+    "INPUT_FTP_SSL_ALLOW=false"
+}
+
+# run_init ENV_VARS TIMEOUT_SECONDS
+#   Runs init.sh in alpine, returns combined stdout+stderr.
+run_init() {
+  _env=$1
+  _t=${2:-15}
+  _env_file=$(mktemp) || return 1
+  {
+    common_env
+    printf '%s\n' "${_env}"
+  } > "${_env_file}"
+  ${RUNTIME} run --rm \
+    -v "${ROOT}:/app:ro" \
+    -w /app \
+    --env-file "${_env_file}" \
+    alpine:3.23.3 \
+    /bin/sh -c "apk add --no-cache lftp ca-certificates >/dev/null 2>&1 && timeout ${_t} sh ${INIT_REL} 2>&1; echo EXIT=\$?" \
+    2>&1
+  rm -f "${_env_file}"
+}
+
+# ----------------------------------------------------------------------------
+# Test 1: max_retries=abc → exit 2 with clear error
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_MAX_RETRIES=abc" 10)
+echo "${out}" | grep -q "max_retries must be a non-negative integer" \
+  || fail "max_retries=abc did not produce validation error; output was:\n${out}"
+echo "${out}" | grep -q "^EXIT=2" \
+  || fail "max_retries=abc did not exit 2; output was:\n${out}"
+pass "max_retries=abc produces clear error and exits 2"
+
+# ----------------------------------------------------------------------------
+# Test 2: unreachable server → exit 1 after retries exhausted
+# ----------------------------------------------------------------------------
+out=$(run_init "" 30)
+echo "${out}" | grep -q "lftp exited with code" \
+  || fail "unreachable server did not produce lftp exit code message; output was:\n${out}"
+echo "${out}" | grep -q "ERROR: UPLOAD FAILED" \
+  || fail "unreachable server did not produce final ERROR banner; output was:\n${out}"
+echo "${out}" | grep -q "^EXIT=1" \
+  || fail "unreachable server did not exit 1; output was:\n${out}"
+pass "unreachable server exits 1 with lftp error message"
+
+# ----------------------------------------------------------------------------
+# Test 3: debug=true echoes the password
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_DEBUG=true" 30)
+echo "${out}" | grep -q "password:[[:space:]]*p" \
+  || fail "debug=true did not echo the password value; output was:\n${out}"
+pass "debug=true echoes the password value"
+
+# ----------------------------------------------------------------------------
+# Test 4: default dump does NOT echo the password value
+# ----------------------------------------------------------------------------
+# Use a distinctive password so we can grep for it precisely.
+out=$(run_init "INPUT_PASSWORD=SecretTokenDoNotLeakXYZ" 30)
+echo "${out}" | grep -q "SecretTokenDoNotLeakXYZ" \
+  && fail "default dump leaked the password value; output was:\n${out}"
+pass "default dump does not echo the password value"
+
+# ----------------------------------------------------------------------------
+# Test 5: mirror_verbose is honoured (output mentions verbose=2)
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_MIRROR_VERBOSE=2" 30)
+echo "${out}" | grep -q "MIRROR_COMMAND.*--verbose=2" \
+  || fail "mirror_verbose=2 was not reflected in MIRROR_COMMAND; output was:\n${out}"
+pass "mirror_verbose is honoured by init.sh"
+
+# ----------------------------------------------------------------------------
+# Test 6: backoff between attempts is visible in the log
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_MAX_RETRIES=2" 30)
+echo "${out}" | grep -q "Backing off" \
+  || fail "retry backoff not visible in the log; output was:\n${out}"
+pass "retry backoff is visible in the log"
+
+printf 'All smoke tests passed.\n'
+exit 0


### PR DESCRIPTION
Closes #39.

## Summary

P0/P1 quality fixes from the internal audit. All backward-compatible
— no input defaults change, no new required inputs, no behaviour
change for the happy path.

## What changes

**Bug fixes**

- **B-01 / B-12** — `mirror_verbose` and `lftp_settings` are now
  declared in `action.yml` (previously referenced in `init.sh` and
  the README but invisible as inputs).
- **B-05** — `lftp` exit code is captured explicitly so the
  `ERROR: UPLOAD FAILED` banner always runs on failure; the last
  lftp exit code is printed in the banner for easier debugging.
- **B-06** — `${INPUT_MAX_RETRIES}` is now quoted in the comparison
  (shellcheck SC2086).
- **B-07** — `max_retries`, `mirror_verbose`, `ftp_nop_interval`,
  `net_max_retries`, `net_persist_retries`, and `dns_max_retries`
  are validated as non-negative integers; the action exits with
  code `2` and a clear error on bad input.
- **B-08** — Retry backoff is now exponential (1s, 2s, 4s, 8s, 16s,
  capped at 30s) with ±50% jitter, replacing the flat 60s sleep.
- **B-09** — A hard 5-hour wall-clock timeout (with 30s SIGKILL
  grace) wraps every `lftp` call so a hung transfer cannot outlive
  the job.
- **B-10** — Input values are no longer printed to the workflow log
  by default; the dump shows only `(set)` / `(using default)` per
  input. New `debug` input (default `false`) re-enables the full
  dump for troubleshooting.
- **B-11** — README now explicitly distinguishes the minimal
  example from the "no defaults" extended example.
- **B-15** — `.dockerignore` added; verified that the resulting
  image contains only `init.sh`, `README.md` and `LICENSE` under
  `/app/`.

**New artifacts**

- `SECURITY.md` — private disclosure policy and supported-versions
  table.
- `CHANGELOG.md` — Keep a Changelog format with a full `Unreleased`
  section.
- `tests/contract.sh` (POSIX-only) — would have caught B-01.
  Asserts that every `INPUT_*` in `init.sh` is declared in
  `action.yml` and that the dump loop's name list matches.
- `tests/smoke.sh` (POSIX-only, runs `init.sh` in alpine via
  docker) — covers integer validation, exit codes on unreachable
  server, debug-toggle redaction, `mirror_verbose` wiring, and
  backoff visibility.
- `.github/workflows/ci.yml` — runs shellcheck, actionlint, hadolint
  (info-level only for now), the contract test, and the smoke tests
  on every push and PR.

## Why

The audit found that `mirror_verbose` and `lftp_settings` were
invisible to users despite being documented, that the failure path
silently bypassed the `ERROR` banner, that integer inputs could
crash the script with a syntax error, and that a flat 60s backoff
plus an unbounded wall-clock `lftp` invocation could cost up to 9
minutes of pure sleeping per failure. The log dump additionally
leaked server, user, and path values by default. None of these
behaviours were visible to users until something went wrong.

The fix bundle keeps the contract stable: the defaults are
unchanged for every existing input, no input becomes required, and
the happy path produces the same `lftp` command it did before.

## Validation

All checks pass locally:

- `shellcheck init.sh tests/contract.sh tests/smoke.sh` → clean.
- `actionlint .github/workflows/ci.yml` → clean.
- `hadolint --failure-threshold error Dockerfile` → only the
  expected `DL3018` warning (`apk add` without pinned versions),
  documented as out of scope for this PR and addressed alongside
  image digest pinning in a follow-up.
- `tests/contract.sh` → 22 inputs, static `INPUT_*` references and
  the dump loop's name list all match.
- `tests/smoke.sh` → 6/6 tests pass (integer validation, exit code
  on unreachable server, debug redaction, `mirror_verbose` wiring,
  backoff visibility).
- `docker build .` → 15.2 MB image; `/app/` contains only
  `init.sh`, `README.md`, `LICENSE` (the `.dockerignore` is
  effective).

## Out of scope (deferred to follow-up PRs)

- MP-1 (invert `ssl_verify_certificate` default to `true`) —
  breaking change, requires v2.0.0. Decision recorded, tracked
  separately.
- B-03 (`.netrc` + `trap EXIT`), B-04 (path traversal
  sanitization), B-14 (non-root USER), B-16 (`lftp_settings`
  sanitization) — security hardening bundle.
- B-13 (image digest pinning), B-17 (signed tags) — release
  pipeline work.
- B-18 (recommend `@v1` over `@latest` in the README).