### PR TITLE
feat!: invert ssl_verify_certificate default (v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - TBD
+
+### Breaking
+
+- `ssl_verify_certificate` default changed from `"false"` to `"true"`.
+  This is a behaviour change for every existing v1.x user that relied
+  on the lax default to connect to a self-signed or direct-IP
+  server. With v2.0.0, the action refuses to connect to a server
+  with an invalid, expired, or hostname-mismatched certificate.
+  To opt back into the v1.x behaviour, set
+  `ssl_verify_certificate: "false"` explicitly in your workflow.
+
+  This is the breaking change promised in the original audit
+  (PROPOSAL.md §3.1 #1 and the MP-1 entry). All other v1.x→v2.0.0
+  changes are behaviour-preserving (the security hardening and
+  validation work in v1.4.0 and v1.5.0 is compatible with the
+  v1.x contract).
+
+### Changed
+
+- README: the "Security and SSL" section now documents the new
+  default and the opt-out path; the warning is no longer about a
+  known-insecure default but about the rare case of a user
+  explicitly opting back into the v1.x lax behaviour.
+
 ## [Unreleased]
 
 ### Added
@@ -81,5 +106,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Historical. See git history for changes prior to `CHANGELOG.md` adoption.
 
-[Unreleased]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.3.3...HEAD
+[Unreleased]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.3.3...v2.0.0
 [1.3.3]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.3.3

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This GitHub action copies the files via FTP from your Git project to your server
 
 ## Security and SSL
 
-By default, `ftp_ssl_allow` is set to `true` to ensure your connection is encrypted. However, `ssl_verify_certificate` is set to `false` by default. This means your data is encrypted during transfer, but the Action does not verify if the server's certificate is valid or matches the hostname. This prevents connection errors with self-signed certificates or direct IP connections but leaves you vulnerable to Man-in-the-Middle (MITM) attacks if someone spoofs your DNS.
+By default, `ftp_ssl_allow` is set to `true` to ensure your connection is encrypted, and `ssl_verify_certificate` is also set to `true`, so the action refuses to connect to a server with an invalid, expired, or hostname-mismatched certificate. **This is a breaking change from v1.x**: if you connect to a server with a self-signed certificate or a direct IP, the action will now fail with a TLS error. To opt back into the v1.x behaviour, set `ssl_verify_certificate: false` explicitly in your workflow.
 
-If you require strict security, set `ssl_verify_certificate: true` and ensure your server has a valid certificate matching the hostname used.
+> **Note on direct-IP connections**: lftp cannot validate a hostname against an IP-address certificate, so `ssl_verify_certificate: true` requires both a valid certificate and a hostname (not a bare IP) in the `server` input.
 
 ## Usage Example
 

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
   ssl_verify_certificate:
     description: 'Verify SSL certificate.'
     required: false
-    default: 'false'
+    default: 'true'
   ssl_check_hostname:
     description: 'Check certificate hostname.'
     required: false

--- a/init.sh
+++ b/init.sh
@@ -189,7 +189,7 @@ fi
 if [ -n "${INPUT_SSL_VERIFY_CERTIFICATE}" ]; then
   FTP_SETTINGS="${FTP_SETTINGS}set ssl:verify-certificate ${INPUT_SSL_VERIFY_CERTIFICATE};"
 else
-  FTP_SETTINGS="${FTP_SETTINGS}set ssl:verify-certificate false;"
+  FTP_SETTINGS="${FTP_SETTINGS}set ssl:verify-certificate true;"
 fi
 
 # ssl:check-hostname


### PR DESCRIPTION
Closes #43.

## ⚠️ Breaking change

This PR flips the default of `ssl_verify_certificate` from `"false"`
to `"true"`. This is the v2.0.0 cut the audit called for
(PROPOSAL.md §3.1 #1, MP-1). **Every existing v1.x user that
connects to a self-signed or direct-IP server will need to add
one line to their workflow**, or their upload will fail with a
TLS error after this lands.

```yaml
- uses: airvzxf/ftp-deployment-action@v2
  with:
    server: ${{ secrets.FTP_SERVER }}
    user:   ${{ secrets.FTP_USERNAME }}
    password: ${{ secrets.FTP_PASSWORD }}
    ssl_verify_certificate: 'false'   # opt back into v1.x behaviour
```

Users that want to stay on the v1.x line forever can pin to
`airvzxf/ftp-deployment-action@v1` and never see this PR. The
recommended release process (out of scope here) is to tag the
previous commit as `v1.5.0` / `v1` immediately after this PR
merges, and then tag the merge commit as `v2.0.0` / `v2`.

## What changes

- `action.yml`: `ssl_verify_certificate` default `"false"` →
  `"true"`.
- `init.sh`: matching default in the `FTP_SETTINGS` block
  (only relevant outside the GH Actions defaulting mechanism):
  `false` → `true`.
- `README.md`: the "Security and SSL" section is rewritten to
  document the new default, the opt-out path, and the
  hostname-vs-IP note (lftp cannot validate a hostname against
  an IP-address certificate, so `ssl_verify_certificate: true`
  requires a hostname, not a bare IP).
- `CHANGELOG.md`: new `## [2.0.0] - TBD` section that calls out
  the breaking change. The `[Unreleased]` section is preserved
  for future work; the version comparator links are updated to
  compare against `v2.0.0` instead of `HEAD`.

## Why

The audit (§3.1) called this out as the highest-priority security
item: the action advertises itself as "vulnerable to MITM" in its
own README and still ships that as the default. A deprecation
period (v1.x with a warning, then v2.0.0 with the flip) was
considered and rejected — the v1.x default is dangerous enough that
the right answer is to require the user to *opt into* the lax
behaviour, not opt out of it.

The v1.4.0 (PR #40) and v1.5.0 (PR #42) work is all
behaviour-preserving on purpose: no input defaults change, no
input becomes required. This means every user that wants to stay
on the v1.x contract forever can pin to `v1` and never be affected
by this PR.

## Validation

All checks pass locally:

- `shellcheck init.sh tests/contract.sh tests/smoke.sh` → clean.
- `actionlint .github/workflows/ci.yml` → clean.
- `hadolint --failure-threshold error Dockerfile` → only the
  expected `DL3018` warning.
- `tests/contract.sh` → 22 inputs, static `INPUT_*` references and
  the dump loop's name list all match (no input was added or
  removed).
- `tests/smoke.sh` → 15/15 pass. The change is a one-line default
  flip, no other code paths are affected; the existing tests
  exercise the same code with the new default applied.
- `docker build` + `docker run` → image still 15.2 MB, runs as
  `lftp`, `HOME=/home/lftp`, `init.sh` entrypoint works.

## Out of scope (deferred to follow-up PRs)

- B-13 (image digest pinning), B-17 (signed tags) — release
  pipeline work. Will land on top of v2.0.0.
- The release tagging itself (`v2.0.0`, `v2`, `v1.5.0`, `v1` floating
  major tag) — release-engineering work, not part of this code
  change.

## Suggested merge strategy

This is a `feat!:` (conventional-commits breaking-change prefix)
commit. **Squash-merge to master** to keep history linear. After
merge, follow the release process in #43 to cut v1.5.0 and v2.0.0.