### PR TITLE
feat(ci): release pipeline to ghcr.io with cosign signing and SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+# Trigger on every pushed tag matching v*.*.* (e.g. v2.0.1, v2.1.0,
+# v3.0.0-rc.1). The previous workflow on push: branches:[master] is
+# unaffected; this one only fires on tag pushes.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to release (e.g. v2.0.1). Must already exist on the remote.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    name: Build, sign and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag and version
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.version }}"
+          else
+            tag="${{ github.ref_name }}"
+          fi
+          version="${tag#v}"
+          image="ghcr.io/${{ github.repository_owner }}/ftp-deployment-action"
+          {
+            echo "tag=${tag}"
+            echo "version=${version}"
+            echo "image=${image}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag}, version=${version}, image=${image}"
+
+      - name: Checkout source at the release tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.meta.outputs.tag }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
+          labels: |
+            org.opencontainers.image.title=ftp-deployment-action
+            org.opencontainers.image.description=GitHub Action that copies files via FTP/FTPS using lftp
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.licenses=GPL-3.0
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
+          format: cyclonedx-json
+          artifact-name: sbom.cyclonedx.json
+
+      - name: Sign image with cosign (keyless, OIDC)
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+        run: |
+          cosign sign --yes \
+            ${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}
+
+      - name: Attach SBOM attestation to the image
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.meta.outputs.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.cyclonedx.json
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,35 @@ malformed input).
 
 Historical. See git history for changes prior to `CHANGELOG.md` adoption.
 
+## [Unreleased]
+
+### Added
+- `.github/workflows/release.yml`: on every pushed `v*.*.*` tag
+  (and via manual `workflow_dispatch` with a tag input), the
+  workflow:
+  - builds the Docker image with `docker/build-push-action@v6`
+    using GitHub Actions cache (`type=gha`),
+  - pushes the result to `ghcr.io/airvzxf/ftp-deployment-action`
+    with tags `<version>` and `v<version>` plus OCI image labels
+    (source, license, version),
+  - generates a CycloneDX SBOM with `anchore/sbom-action@v0` and
+    attaches it to the image as an in-toto attestation via
+    `actions/attest@v4`,
+  - signs the image with `cosign sign --yes` (keyless, OIDC).
+  After this lands, the next `v2.x.y` tag will produce a signed
+  image at `ghcr.io/airvzxf/ftp-deployment-action:<version>` with
+  an attached SBOM, automatically.
+
+### Fixed
+- B-13: Dockerfile now pins the base image by digest
+  (`alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659`,
+  the digest of `alpine:3.23.3` at the time of v2.0.1). The
+  package versions are pinned too (`lftp=4.9.2-r9`,
+  `ca-certificates=20260611-r0`), which resolves hadolint
+  `DL3018`. Bumping the base image is now a controlled cadence
+  done via the release pipeline; the next bump will need a digest
+  refresh in the same commit that bumps the tag.
+
 [Unreleased]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.0.1...HEAD
 [2.0.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM alpine:3.23.3
+FROM alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
-# B-14: create an unprivileged user and group for lftp to run as.
-# All credentials, cache and .netrc files are written under this user's
-# $HOME (/home/lftp), so the user must own it before the USER directive.
-RUN apk add --no-cache lftp ca-certificates \
+# B-13: pin the base image by digest (resolved against the alpine:3.23.3
+# tag at the time of v2.0.1). Bump on a controlled cadence via the
+# release pipeline; the digest is recorded in the corresponding tag
+# message.
+#
+# Pin the package versions too (resolves hadolint DL3018).
+# lftp=4.9.2-r9 and ca-certificates=20260611-r0 are the current
+# versions in alpine 3.23.3; bump them together with the base image.
+RUN apk add --no-cache \
+      lftp=4.9.2-r9 \
+      ca-certificates=20260611-r0 \
  && addgroup -S lftp \
  && adduser -S lftp -G lftp -h /home/lftp \
  && mkdir -p /home/lftp \


### PR DESCRIPTION
Closes #45.

## Summary

Adds the release pipeline that the audit (PROPOSAL.md §3.9, §3.12)
called for. After this lands, every pushed `v*.*.*` tag produces
a signed image at `ghcr.io/airvzxf/ftp-deployment-action` with an
attached CycloneDX SBOM, automatically. The `Dockerfile` is also
pinned to a known-good digest and apk versions, resolving the
`DL3018` hadolint warning that was open since the first PR.

No user-facing behaviour change. The next `v2.x.y` tag (proposed:
v2.0.1) will trigger the new workflow; v2.0.0 and v1.5.0 are
unaffected because they predate it.

## What changes

- **Dockerfile** — `FROM alpine:3.23.3` →
  `FROM alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659`.
  `apk add lftp ca-certificates` →
  `apk add lftp=4.9.2-r9 ca-certificates=20260611-r0`. The digest and
  versions are the ones current at `alpine:3.23.3` (v2.0.1 baseline).
- **`.github/workflows/release.yml`** — new workflow, see below.
- **CHANGELOG.md** — new `[Unreleased]` entry.

## The release workflow

Fires on `push: tags: [v[0-9]+.[0-9]+.[0-9]+*]` and on
`workflow_dispatch` (with a `version` input for back-fills). Required
permissions: `contents:read`, `packages:write`, `id-token:write`,
`attestations:write`. Steps:

1. **Resolve tag and version** — `version=${tag#v}`.
2. **Checkout source at the tag** — `actions/checkout@v4` with
   `ref: <tag>` and `fetch-depth: 0`.
3. **Log in to ghcr.io** — `docker/login-action@v3` with the
   `GITHUB_TOKEN`.
4. **Build and push image** — `docker/build-push-action@v6` with
   `cache-from: type=gha` / `cache-to: type=gha,mode=max` and OCI
   image labels (source, license, version). Two tags per push:
   `v<version>` and `<version>`.
5. **Generate SBOM (CycloneDX)** — `anchore/sbom-action@v0`,
   `format: cyclonedx-json`. Also uploaded as a workflow artifact.
6. **Sign image with cosign (keyless, OIDC)** —
   `cosign sign --yes ghcr.io/...@$digest`. No key management
   required; provenance is in the OIDC token.
7. **Attach SBOM attestation to the image** — `actions/attest@v4`
   (the modern replacement for the deprecated `actions/attest-sbom`)
   with `subject-digest`, `subject-name` and `sbom-path`. The
   SBOM is attached as an in-toto attestation that consumers can
   retrieve with `cosign verify-attestation` or
   `gh attestation verify`.

## Why

Every existing v1.x and v2.0.0 image is published to Docker Hub
without provenance. With this PR, every future `v2.x.y` tag will
produce a signed image with an attached SBOM at
`ghcr.io/airvzxf/ftp-deployment-action:<version>`, automatically.
The action's `runs.image` can stay on `'Dockerfile'` (which uses
the local Dockerfile in the repo); the published image is a
side benefit for anyone who wants to inspect the supply chain.

## Validation

All checks pass locally:

- `shellcheck init.sh tests/contract.sh tests/smoke.sh` → clean.
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
  → clean.
- `hadolint --failure-threshold error Dockerfile` → clean (the
  `DL3018` warning is now resolved by the apk version pins).
- `tests/contract.sh` → 22 inputs, static `INPUT_*` references and
  the dump loop's name list all match.
- `tests/smoke.sh` → 15/15 pass.
- `docker build` → image is 15.2 MB, runs as `lftp`, `HOME=/home/lftp`.

## Out of scope (deferred to follow-up PRs)

- `latest` tag handling: the existing v1.3.1 `latest` release is
  stale; the v2.0.0 release is marked as "Latest" in the GitHub
  UI but not as the `latest` tag. The release workflow does not
  currently update the `latest` release. If you want a `latest`
  release pushed alongside every release, add it to the
  `tags:` list in the build step.
- B-18 (recommend `@v1` over `@latest` in the README) — README
  change, unrelated to the pipeline.