### PR TITLE
chore: prepare default-branch rename master -> main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    # Both `main` (the new default) and `master` (the legacy default)
+    # are listed during the transition period. Once `master` is removed
+    # from the remote (a follow-up step in this change), narrow this
+    # back to [main] in a one-line follow-up commit.
+    branches: [main, master]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 # Trigger on every pushed tag matching v*.*.* (e.g. v2.0.1, v2.1.0,
-# v3.0.0-rc.1). The previous workflow on push: branches:[master] is
-# unaffected; this one only fires on tag pushes.
+# v3.0.0-rc.1). Tag pushes fire on any branch; this workflow does not
+# filter by branch, so the release pipeline works the same on `main`,
+# `master`, or any feature branch used for a hotfix release.
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ jobs:
           local_dir: "./public_html"
 ```
 
-Optionally, you can get the live version which has the last commits using the `master` branch like this:
-`uses: airvzxf/ftp-deployment-action@master`.
+Optionally, you can get the live version which has the last commits using the `main` branch like this:
+`uses: airvzxf/ftp-deployment-action@main`.
 
 ## Settings
 


### PR DESCRIPTION
## Summary

Code-only preparation for the default-branch change from
`master` to `main`. The actual branch switch on the remote
(creating `main`, setting it as the default, deleting `master`)
is done as a follow-up after this PR merges.

## What changes

- `.github/workflows/ci.yml`: `branches: [master]` becomes
  `branches: [main, master]` so CI keeps running on both
  branches during the transition. A follow-up commit will narrow
  this back to `[main]` after `master` is removed from the remote.
- `.github/workflows/release.yml`: comment near `on:` is
  updated to make explicit that the release workflow filters by
  tag, not by branch.
- `README.md`: the "Optionally, you can get the live version"
  block at the bottom of the Usage Example now references the
  `main` branch.

## Out of scope (deferred to a follow-up after this PR merges)

- Creating the `main` branch on the remote (push the current
  `master` HEAD to a new ref called `main`).
- Setting the default branch to `main` via
  `gh api -X PATCH repos/airvzxf/ftp-deployment-action
  -f default_branch=main` (or the GitHub UI).
- Deleting the `master` branch on the remote.
- Narrowing `ci.yml` back to `branches: [main]` (one-line
  follow-up after `master` is gone).

## Validation

- `shellcheck init.sh tests/contract.sh tests/smoke.sh` → clean.
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
  → clean.
- `tests/contract.sh` → 22 inputs, static `INPUT_*` references
  and the dump loop's name list all match (no input was added
  or removed).