### PR TITLE
chore(ci): bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install shellcheck
         run: |
           sudo apt-get update
@@ -31,7 +31,7 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # rhysd/actionlint is a Go binary, not a JavaScript action. We install
       # it directly from the upstream release instead of using a wrapper
       # action, which keeps the dependency footprint small and the version
@@ -52,7 +52,7 @@ jobs:
     name: hadolint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Pin to a specific tag because the upstream has no floating "v3" ref
       # (only v3.0.0, v3.1.0, ...). Using `@v3` makes the resolver fail.
       - uses: hadolint/hadolint-action@v3.1.0
@@ -67,7 +67,7 @@ jobs:
     name: Contract test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify action.yml ↔ init.sh consistency
         run: tests/contract.sh
 
@@ -75,6 +75,6 @@ jobs:
     name: Smoke tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run init.sh smoke tests in alpine
         run: tests/smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Resolved tag=${tag}, version=${version}, image=${image}"
 
       - name: Checkout source at the release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ steps.meta.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ Historical. See git history for changes prior to `CHANGELOG.md` adoption.
 
 ## [Unreleased]
 
+### Changed
+- CI and release workflows now use `actions/checkout@v5` (was v4).
+  v5 targets Node 24, which silences the deprecation warning
+  every push produced since Node 20 was deprecated on the GH
+  Actions runners. No user-facing behaviour change.
+
 ### Added
 - `.github/workflows/release.yml`: on every pushed `v*.*.*` tag
   (and via manual `workflow_dispatch` with a tag input), the


### PR DESCRIPTION
Bumps `actions/checkout` from v4 to v5 across both workflows
(`ci.yml`, `release.yml`). v5 targets Node 24, which silences the
deprecation warning that every CI run on the v2.x line produced
since Node 20 was deprecated on the GH Actions runners
(2025-09-19).

The Node 20 warning specifically named `actions/checkout@v4` as
one of the actions that was being "forced to run on Node 24"
anyway, so the runtime effect is null; the v5 bump just gets
the runners to stop complaining in the Actions UI.

## What changes

- `.github/workflows/ci.yml`: 5 occurrences of
  `actions/checkout@v4` → `actions/checkout@v5`.
- `.github/workflows/release.yml`: 1 occurrence.
- `CHANGELOG.md`: noted under `[Unreleased] / Changed`.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
  → clean.
- This commit on the branch triggers the CI run on push to
  `main`; the Node 20 warning should be gone from the next run's
  annotations.

## Why a separate PR

The bump is a one-character change in six places but the user
facing CI behaviour change (no more Node 20 warning) is
observable. Easier to review and revert in isolation than as
part of a larger change.