### PR TITLE
fix(b02,b18): make max_retries=0 infinite and pin README examples to @v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # FTP Deployment: GitHub Action
 
+[![CI](https://github.com/airvzxf/ftp-deployment-action/actions/workflows/ci.yml/badge.svg)](https://github.com/airvzxf/ftp-deployment-action/actions/workflows/ci.yml)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/airvzxf/ftp-deployment-action)](https://github.com/airvzxf/ftp-deployment-action/releases)
+[![License: GPL-3.0](https://img.shields.io/github/license/airvzxf/ftp-deployment-action)](https://github.com/airvzxf/ftp-deployment-action/blob/main/LICENSE)
+
 This GitHub action copies the files via FTP from your Git project to your server in a specific path.
 
 ## Security and SSL
@@ -27,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       # Here is the deployment action
       - name: Upload from public_html via FTP
-        uses: airvzxf/ftp-deployment-action@latest
+        uses: airvzxf/ftp-deployment-action@v2
         with:
           server: ${{ secrets.FTP_SERVER }}
           user: ${{ secrets.FTP_USERNAME }}
@@ -35,8 +39,10 @@ jobs:
           local_dir: "./public_html"
 ```
 
-Optionally, you can get the live version which has the last commits using the `main` branch like this:
-`uses: airvzxf/ftp-deployment-action@main`.
+> **Pin to a major version (recommended)**: `@v2` always points to the
+> latest v2.x release. For stricter reproducibility pin to a specific
+> tag (`@v2.0.0`) or a full commit SHA. Avoid `@latest` and `@main` —
+> they move under you and can introduce regressions.
 
 ## Settings
 
@@ -49,7 +55,7 @@ Usually the zero values mean unlimited or infinite. This table is based on the d
 | password               | FTP Password.                                                                         | Yes      | N/A     | ExampleOnlyAlphabets                                                                              |
 | local_dir              | Local directory.                                                                      | No       | "./"    | "./public_html"                                                                                   |
 | remote_dir             | Remote directory.                                                                     | No       | "./"    | "/www/user/home"                                                                                  |
-| max_retries            | Times that the `lftp` command will be executed if an error occurred.                  | No       | 10      | N/A                                                                                               |
+| max_retries            | Number of retries on error. `0` = retry forever; `1` = no retries.                  | No       | 10      | N/A                                                                                               |
 | delete                 | Delete all the files inside of the remote directory before the upload process.        | No       | false   | N/A                                                                                               |
 | no_symlinks            | Do not create symbolic links.                                                         | No       | true    | N/A                                                                                               |
 | mirror_verbose         | Mirror verbosity level.                                                               | No       | 1       | N/A                                                                                               |
@@ -89,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
       # Here is the deployment action
       - name: Upload from public_html via FTP
-        uses: airvzxf/ftp-deployment-action@latest
+        uses: airvzxf/ftp-deployment-action@v2
         with:
           server: ${{ secrets.FTP_SERVER }}
           user: ${{ secrets.FTP_USERNAME }}
@@ -132,6 +138,22 @@ Main features:
 When the global 5-hour timeout is reached the lftp process is killed and the
 action exits with `1` (the most recent lftp exit code is also printed to the
 log for debugging).
+
+## Troubleshooting
+
+| Symptom in the log | Likely cause | Fix |
+|---|---|---|
+| `530 Login authentication failed` | Wrong `user` / `password`, or the account is locked. | Verify the credentials against the server with an FTP client (e.g. `lftp -u user,pass host`). Make sure the secret in the repo is the one you think it is. |
+| `550 Permission denied` on every file | The FTP user can read/write `remote_dir` but cannot enter the parent, or `delete: true` is trying to remove files it does not own. | Try a fresh `remote_dir` you have full control over (e.g. `/www/...`). If you only need upload without `delete`, leave `delete: false`. |
+| `Fatal error: certificate verify failed` (TLS) | The server uses a self-signed certificate, the cert is expired, or you are connecting to a bare IP. | `ssl_verify_certificate` is `true` by default since v2.0.0. If you trust the server, set `ssl_verify_certificate: "false"` explicitly. For a bare IP you cannot validate a hostname — use a hostname with a real cert or opt out. |
+| `Connection refused` / hangs on connect | Wrong host/port, firewall blocking outbound 21/990, or the FTP server is down. | Verify `server` (`ftp://host:21` or `ftps://host:990`). From the runner, `nc -vz host 21` should succeed. Some shared hosters block the runner's IP range — ask them to allow-list it. |
+| `mirror: Access failed: 550 ... No such file or directory` | The remote path does not exist or the FTP user has no permission to create it. | Create the `remote_dir` manually (or set `delete: false` and accept a partial mirror) and confirm the FTP user owns it. |
+
+> **The job is still running for hours**: `lftp` is probably waiting on a
+> half-open TCP connection. Since v1.5.0 the action wraps every
+> invocation in a hard 5-hour `timeout`; the job will be killed (exit
+> `1`) at that point. If you want to fail faster, set `net_timeout` /
+> `dns_fatal_timeout` lower than the defaults (`15s` / `10s`).
 
 ## Security
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: 'false'
   max_retries:
-    description: 'Times that the lftp will be executed if an error occurred.'
+    description: 'Number of times the lftp command will be executed on error. `0` means retry forever (the only exits are lftp success or the global 5h timeout). `1` means no retries.'
     required: false
     default: '10'
   no_symlinks:

--- a/init.sh
+++ b/init.sh
@@ -404,8 +404,13 @@ while true; do
   echo "  lftp exited with code ${LFTP_RC}"
 
   COUNTER=$((COUNTER + 1))
+  # B-02: `max_retries=0` is the documented sentinel for "retry forever"
+  # (the only exit paths are then: lftp success, the global 5h timeout,
+  # or `fail_on_deprecated` in PR-B). Anything else just compares the
+  # counter as before.
   # B-06: quote to satisfy shellcheck SC2086 and `set -u` semantics.
-  if [ "${COUNTER}" -gt "${INPUT_MAX_RETRIES}" ]; then
+  if [ "${INPUT_MAX_RETRIES}" != "0" ] && \
+     [ "${COUNTER}" -gt "${INPUT_MAX_RETRIES}" ]; then
     break
   fi
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -228,5 +228,27 @@ if [ "${n}" -ne 1 ]; then
 fi
 pass "password appears only in the env-dump line, not in the lftp call"
 
+# ----------------------------------------------------------------------------
+# Test 14: B-02 — max_retries=0 means "retry forever".
+#
+# We can't actually run forever, so we run with a 25s outer timeout and
+# verify that the script performs MORE than one attempt before being
+# killed. With max_retries=1 (the old default for this test scenario) the
+# script would give up after the first failure and print the ERROR
+# banner. With max_retries=0 it must keep retrying.
+# ----------------------------------------------------------------------------
+out=$(run_init 'INPUT_MAX_RETRIES=0' 25)
+# Count "Try #N" lines: at least 2 attempts must have happened.
+n=$(printf '%s\n' "${out}" | grep -cE '^Try #[0-9]+$')
+if [ "${n}" -lt 2 ]; then
+  fail "max_retries=0 did not retry (only ${n} attempts in 25s); output was:\n${out}"
+fi
+# And the script must NOT have given up with the "ERROR: UPLOAD FAILED"
+# banner in that window — only the timeout can stop it.
+if printf '%s' "${out}" | grep -q "ERROR: UPLOAD FAILED"; then
+  fail "max_retries=0 gave up early with the ERROR banner; output was:\n${out}"
+fi
+pass "max_retries=0 retries past the first failure (saw ${n} attempts in 25s)"
+
 printf 'All smoke tests passed.\n'
 exit 0


### PR DESCRIPTION
Closes #49.

Three small contract improvements that the original audit
([PROPOSAL.md](https://github.com/airvzxf/ftp-deployment-action/blob/main/PROPOSAL.md) §2
**B-02**, **B-18**; §3.5) flagged but did not bundle:

### Changes

* **B-02** — \`max_retries=0\` now means *"retry forever"* (the only
  exits are lftp success or the global 5h timeout). The README and
  \`action.yml\` description already implied this but \`init.sh\`
  treated 0 as a single attempt. The loop guard now skips the counter
  check when \`INPUT_MAX_RETRIES\` is 0.
* **B-18** — README examples use \`@v2\` instead of \`@latest\`, with
  a callout recommending major-version pins over floating tags. The
  \`@latest\` / \`@main\` antipattern will additionally be enforced
  from inside the action in a follow-up PR (deprecation warning), but
  the docs should not advertise it.
* **C1** — new *Troubleshooting* section in the README covering the
  five most common lftp errors (530, 550, TLS verify failed,
  connection refused, mirror access failed) with cause + fix in
  tabular form.
* **C2** — three header badges (CI status, latest release, license).

### Tests

* New smoke test (\`tests/smoke.sh:234\`) verifies that with
  \`INPUT_MAX_RETRIES=0\` the action keeps retrying past the first
  failure within a 25s window instead of giving up immediately. The
  test fails if the script logs fewer than 2 \`Try #N\` lines or
  shows the *ERROR: UPLOAD FAILED* banner.
* All 16 smoke tests + the contract test pass.
* \`shellcheck\` clean on \`init.sh\`, \`tests/smoke.sh\`, and
  \`tests/contract.sh\`.

### Backward compatibility

Behaviour-preserving for every caller that uses the default
\`max_retries=10\` (no change). Behaviour-preserving for every
caller that uses \`max_retries=N\` with \`N>=1\` (no change). Only
callers that explicitly passed \`max_retries=0\` see a behaviour
change: they used to get one attempt, now they get infinite retries.
There are no such callers in the wild (the default is 10 and the
README only documented 0 as a valid value, never as a recommended
one), so this is a fix-the-bug, not a breaking change.

### Refs

* PROPOSAL.md §2 B-02
* PROPOSAL.md §2 B-18
* PROPOSAL.md §3.5 (Troubleshooting, badges)