### PR TITLE
feat: add dry_run input that previews the mirror plan without changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Usually the zero values mean unlimited or infinite. This table is based on the d
 | dns_fatal_timeout      | DNS - Time for DNS queries.<br> Set to "never" to disable.                            | No       | 10s     | N/A                                                                                               |
 | lftp_settings          | Any other settings that you find in the MAN pages for the LFTP package.               | No       | ""      | "set cache:cache-empty-listings true; set cmd:status-interval 1s; set http:user-agent 'firefox';" |
 | debug                  | If "true", print resolved input values to the log.                                    | No       | false   | N/A                                                                                               |
+| fail_on_deprecated     | If "true", exit 1 when the pinned ref is end-of-life (v1.x).                         | No       | false   | N/A                                                                                               |
+| dry_run                | If "true", compute the mirror plan but do not transfer or delete any file.           | No       | false   | N/A                                                                                               |
 
 More information on the official site for [lftp - Manual pages][2].
 

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,10 @@ inputs:
     description: 'If "true", exit 1 when the ref used to invoke this action is end-of-life (v1.0-alpha.*, v1.1, v1.2.0, v1.3.*). Useful for orgs with a "no EOL versions" policy. The deprecation warning is still printed either way; this input only controls whether the action fails.'
     required: false
     default: 'false'
+  dry_run:
+    description: 'If "true", perform a dry run: lftp will compute the mirror plan but not transfer or delete any file. Useful to preview what the action would change before a destructive run. The action still exits 0 on success (i.e. on a clean dry-run plan) and 1 on a hard error.'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/init.sh
+++ b/init.sh
@@ -217,7 +217,7 @@ else
             NO_SYMLINKS MIRROR_VERBOSE FTP_SSL_ALLOW SSL_VERIFY_CERTIFICATE \
             SSL_CHECK_HOSTNAME FTP_PASSIVE_MODE FTP_USE_FEAT FTP_NOP_INTERVAL \
             NET_MAX_RETRIES NET_PERSIST_RETRIES NET_TIMEOUT DNS_MAX_RETRIES \
-            DNS_FATAL_TIMEOUT LFTP_SETTINGS DEBUG FAIL_ON_DEPRECATED; do
+            DNS_FATAL_TIMEOUT LFTP_SETTINGS DEBUG FAIL_ON_DEPRECATED DRY_RUN; do
     _label=$(printf '%s' "${_v}" | tr '[:upper:]' '[:lower:]')
     eval "_cur=\${INPUT_${_v}}"
     if [ -n "${_cur}" ]; then
@@ -396,6 +396,14 @@ fi
 # Delete files not present at the source
 if [ "${INPUT_DELETE}" = "true" ]; then
   MIRROR_COMMAND="${MIRROR_COMMAND} --delete"
+fi
+
+# Dry run: compute the mirror plan but do not transfer or delete
+# anything. lftp's --dry-run makes mirror print every file it
+# *would* act on, then quit without writing. Safe to combine with
+# --delete: the deletion list is reported but not executed.
+if [ "${INPUT_DRY_RUN}" = "true" ]; then
+  MIRROR_COMMAND="${MIRROR_COMMAND} --dry-run"
 fi
 
 # ------------------------------------------------------------------------------
@@ -598,5 +606,10 @@ fi
 
 echo ""
 echo "=============================="
-echo "=   FTP UPLOADED FINISHED!   ="
+if [ "${INPUT_DRY_RUN}" = "true" ]; then
+  echo "=  FTP DRY RUN COMPLETED     ="
+  echo "=  (no files transferred)    ="
+else
+  echo "=   FTP UPLOADED FINISHED!   ="
+fi
 echo "=============================="

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -371,5 +371,19 @@ echo "${out}" | grep -q "PERMANENT" \
   && fail "A6 classifier incorrectly flagged a transient connection error as permanent; output was:\n${out}"
 pass "A6 classifier does not flag transient connection errors as permanent"
 
+# ----------------------------------------------------------------------------
+# Test 24: dry_run=true — the mirror command gets --dry-run, and the
+# final banner switches to the DRY RUN variant.
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_DRY_RUN=true" 30)
+echo "${out}" | grep -q "MIRROR_COMMAND.*--dry-run" \
+  || fail "INPUT_DRY_RUN=true was not reflected in MIRROR_COMMAND; output was:\n${out}"
+echo "${out}" | grep -q "FTP DRY RUN COMPLETED" \
+  || fail "dry-run final banner was not shown; output was:\n${out}"
+if echo "${out}" | grep -q "FTP UPLOADED FINISHED!"; then
+  fail "dry-run run should not show the regular success banner; output was:\n${out}"
+fi
+pass "dry_run=true adds --dry-run to the mirror command and the DRY RUN banner"
+
 printf 'All smoke tests passed.\n'
 exit 0


### PR DESCRIPTION
A long-standing TODO in the README and a frequently-asked-for
feature: let users see what the action would do before letting
it loose on a production server.

### Changes

When \`dry_run\` is \`true\`:

* the mirror command gets lftp's \`--dry-run\` flag, which makes
  lftp compute the file list and print every file it would
  upload, skip, or delete — without actually touching
  anything;
* the final success banner switches from *FTP UPLOADED
  FINISHED!* to *FTP DRY RUN COMPLETED (no files
  transferred)* so a casual reader cannot mistake a dry run
  for a real upload;
* the failure banner is unchanged (a hard error during the
  plan phase is still a hard error).

Safe to combine with \`delete: "true"\` (the deletion list is
reported but not executed) and with \`no_symlinks: "true"\`
(the plan includes the symlink handling decisions). Exit
codes are unchanged: \`0\` on a clean plan, \`1\` on a hard
error, \`2\` on invalid input (the \`dry_run\` value is not
validated because it is a boolean string).

### Example

```yaml
- name: Preview the FTP deploy
  uses: airvzxf/ftp-deployment-action@v2
  with:
    server: \${{ secrets.FTP_SERVER }}
    user: \${{ secrets.FTP_USERNAME }}
    password: \${{ secrets.FTP_PASSWORD }}
    dry_run: \"true\"
```

### Tests

* Test 24 verifies that \`INPUT_DRY_RUN=true\` adds
  \`--dry-run\` to \`MIRROR_COMMAND\` and switches the final
  banner.
* All 26 smoke tests + contract test pass.
* \`shellcheck\` clean on \`init.sh\` and \`tests/smoke.sh\`.

### Backward compatibility

Behaviour-preserving for the default (\`false\`) and for any
caller that does not set \`dry_run\`.