### PR TITLE
fix(dockerfile): bump lftp pin to 4.9.3-r0 for the new alpine 3.24 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-# B-13: pin the base image by digest (resolved against the alpine:3.23.3
-# tag at the time of v2.0.1). Bump on a controlled cadence via the
+# B-13: pin the base image by digest (resolved against the alpine:3.24
+# tag at the time of v2.3.1). Bump on a controlled cadence via the
 # release pipeline; the digest is recorded in the corresponding tag
 # message.
 #
 # Pin the package versions too (resolves hadolint DL3018).
-# lftp=4.9.2-r9 and ca-certificates=20260611-r0 are the current
-# versions in alpine 3.23.3; bump them together with the base image.
+# lftp=4.9.3-r0 and ca-certificates=20260611-r0 are the current
+# versions in alpine 3.24; bump them together with the base image.
 RUN apk add --no-cache \
-      lftp=4.9.2-r9 \
+      lftp=4.9.3-r0 \
       ca-certificates=20260611-r0 \
  && addgroup -S lftp \
  && adduser -S lftp -G lftp -h /home/lftp \


### PR DESCRIPTION
The Dependabot PR #55 bumped the alpine base image from
3.23.3 (\`sha256:25109184...\`) to a new digest
(\`sha256:28bd5fe8...\`) which corresponds to alpine 3.24 (not
3.23.3 as the comment in the Dockerfile claimed). The new
alpine dropped \`lftp=4.9.2-r9\` and only ships
\`lftp=4.9.3-r0\`, so the package pin in the Dockerfile no
longer resolves and the v2.3.0 release pipeline failed at
the \`apk add\` step:

\`\`\`
ERROR: unable to select packages:
  lftp-4.9.3-r0:
    breaks: world[lftp=4.9.2-r9]
\`\`\`

### Fix

Bump the lftp pin to \`lftp=4.9.3-r0\` (a patch release, no
API change relevant to the action — same 4.9.x line).
\`ca-certificates=20260611-r0\` still resolves against the
new digest, so that pin is left as-is.

Also update the B-13 comment to point at alpine 3.24 instead
of 3.23.3 (the comment was wrong after PR #55 anyway). The
"bump them together with the base image" instruction is
unchanged.

### Validation

* \`shellcheck\` clean on the unchanged \`init.sh\`.
* \`docker build --build-arg VERSION=test .\` succeeds on
  the new digest with the bumped lftp pin.
* The 26 smoke tests + contract test run via CI on the PR
  (they do not exercise the Dockerfile, but they catch any
  regression in \`init.sh\`).

### Note for v2.3.1

This fix unblocks the v2.3.1 release cut. The v2.3.0 tag
already exists in the repo but did not produce a working
image; the release pipeline is idempotent so re-running it
against v2.3.1 will publish a working image at
\`ghcr.io/airvzxf/ftp-deployment-action:2.3.1\` with the
correct SBOM and cosign signature.