### PR TITLE
ci(workflow): bump third-party actions to latest major

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           path: .
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign image with cosign (keyless, OIDC)
         env:


### PR DESCRIPTION
Bump external actions called from `.github/workflows/release.yml` to the latest stable major version.

## What changed

- `sigstore/cosign-installer@v3` → `@v4`

The rest of the action references in this repo were already on the latest major (e.g. `actions/checkout@v7`, `actions/attest@v4`, `docker/setup-buildx-action@v4`).

## Why

`cosign-installer` v4 ships the current cosign binary and is the only line receiving security fixes. v3 still resolves for now but is no longer updated upstream. The input surface used here (no inputs other than the implicit `cosign-version`) is unchanged across the major bump, so the step is a drop-in replacement.

## Verification

- [x] YAML re-validated locally with actionlint (see CI)
- [x] Commit is GPG-signed (verified on the remote)
- [x] Branched off the default branch (`main`)
- [ ] CI green on the PR branch