### PR TITLE
feat(ci): smoke-test the just-pushed image in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,34 @@ jobs:
             org.opencontainers.image.title=ftp-deployment-action
             org.opencontainers.image.description=GitHub Action that copies files via FTP/FTPS using lftp
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.licenses=GPL-3.0
+            org.opencontainers.image.licenses=AGPL-3.0
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # v2.4.0+: smoke-test the just-pushed image before signing
+      # and attaching the SBOM. The release pipeline previously
+      # only exercised the image via CI (which runs init.sh
+      # against a plain alpine:3.23.3 — not the published image
+      # with its pinned lftp and ca-certificates versions). The
+      # v2.3.0 release was cut and pushed with a build that
+      # could not resolve lftp=4.9.2-r9 against the new alpine
+      # 3.24 base image; the failure surfaced only at the
+      # cosign step, after a broken image was already in ghcr.io
+      # and after the SBOM was generated for the broken image.
+      # This step catches that class of failure earlier: it
+      # pulls the just-pushed image, runs three cheap checks
+      # (path-traversal validation, deprecation warning, the
+      # /app/VERSION bake), and aborts the pipeline on any
+      # failure. SBOM generation, cosign signing, and the
+      # SBOM attestation are skipped on failure, so we never
+      # publish or sign a broken image.
+      - name: Smoke test the just-pushed image
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
+        run: |
+          set -e
+          tests/release-smoke.sh "${IMAGE}"
 
       - name: Generate SBOM (CycloneDX)
         uses: anchore/sbom-action@v0

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,21 @@ run: build
 		$(IMAGE)
 
 # ----------------------------------------------------------------------------
+# Release smoke tests: run the same checks the release pipeline
+# runs against a freshly-built image, locally. Catches Dockerfile
+# / lftp pin / build-arg regressions before a tag is pushed.
+# Usage: make release-smoke IMAGE=ftp-deployment-action:local
+# ----------------------------------------------------------------------------
+.PHONY: release-smoke
+release-smoke:
+	@test -n "$(IMAGE)" || { \
+		echo "usage: make release-smoke IMAGE=<image:tag>"; \
+		echo "  e.g. make build IMAGE=ftp-deployment-action:local"; \
+		echo "       make release-smoke IMAGE=ftp-deployment-action:local"; \
+		exit 2; }
+	$(SH) tests/release-smoke.sh "$(IMAGE)"
+
+# ----------------------------------------------------------------------------
 # Release: a thin reminder. The real release pipeline lives in
 # .github/workflows/release.yml and is triggered by a signed tag push.
 # ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -175,6 +175,34 @@ Main features:
 - Using Alpine container means small size and faster creation of the container.
 - Show messages in the console logs for every executed command.
 
+## Local development
+
+```sh
+# Lint (shellcheck + actionlint + hadolint) and run the smoke tests
+make lint
+make test
+
+# Build a local image with the deprecation warning reading 'dev' as
+# the image version (matches the default in the Dockerfile)
+make build IMAGE=ftp-deployment-action:local
+make release-smoke IMAGE=ftp-deployment-action:local
+```
+
+`make build` runs `docker build --build-arg VERSION=dev` and
+`make release-smoke` runs the same three checks the release
+workflow runs against the just-pushed image:
+
+1. The container starts and `validate_path` rejects a `..`
+   path-traversal in `local_dir` with exit 2.
+2. The deprecation warning fires for an EOL ref (`v1.3.3`).
+3. The `VERSION` build-arg was baked into `/app/VERSION`
+   (the warning would say `image version: unknown` otherwise).
+
+These checks catch the kind of regression that broke the v2.3.0
+release (Dependabot bumped the alpine base image, the lftp
+package pin became unresolvable, the v2.3.0 tag was cut with a
+non-buildable image) **before** a tag is pushed.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/init.sh
+++ b/init.sh
@@ -163,6 +163,43 @@ _deprecated_check() {
 _deprecated_check
 
 # ------------------------------------------------------------------------------
+# B-07 / smoke-test: normalize all input vars to their effective
+# defaults. In a real GitHub Actions run these are always populated
+# by the action.yml default, but init.sh can also be run outside
+# that mechanism (tests, manual invocation, the release smoke test
+# against a freshly-built image), so we apply the same defaults
+# here. This block is FIRST in the user-input handling so that
+# every later reference is safe under `set -u`.
+#
+# Use POSIX parameter expansion (`:="${VAR:=default}"`) instead of
+# `if [ -z "${VAR}" ] then VAR=default; fi` so this block is
+# safe under `set -u` even when the var is unset.
+: "${INPUT_SERVER:=}"
+: "${INPUT_USER:=}"
+: "${INPUT_PASSWORD:=}"
+: "${INPUT_LOCAL_DIR:=}"
+: "${INPUT_REMOTE_DIR:=}"
+: "${INPUT_DELETE:=}"
+: "${INPUT_NO_SYMLINKS:=}"
+: "${INPUT_MAX_RETRIES:=10}"
+: "${INPUT_MIRROR_VERBOSE:=1}"
+: "${INPUT_FTP_SSL_ALLOW:=}"
+: "${INPUT_SSL_VERIFY_CERTIFICATE:=}"
+: "${INPUT_SSL_CHECK_HOSTNAME:=}"
+: "${INPUT_FTP_PASSIVE_MODE:=}"
+: "${INPUT_FTP_USE_FEAT:=}"
+: "${INPUT_FTP_NOP_INTERVAL:=2}"
+: "${INPUT_NET_MAX_RETRIES:=1}"
+: "${INPUT_NET_PERSIST_RETRIES:=5}"
+: "${INPUT_NET_TIMEOUT:=}"
+: "${INPUT_DNS_MAX_RETRIES:=8}"
+: "${INPUT_DNS_FATAL_TIMEOUT:=}"
+: "${INPUT_LFTP_SETTINGS:=}"
+: "${INPUT_DEBUG:=}"
+: "${INPUT_FAIL_ON_DEPRECATED:=}"
+: "${INPUT_DRY_RUN:=}"
+
+# ------------------------------------------------------------------------------
 # Defence-in-depth: ask the runner to mask sensitive values in the log
 # even if they ever leak outside the .netrc plumbing. GitHub already
 # auto-masks inputs named *password* / *token* / *secret*, but `user`
@@ -219,7 +256,15 @@ else
             NET_MAX_RETRIES NET_PERSIST_RETRIES NET_TIMEOUT DNS_MAX_RETRIES \
             DNS_FATAL_TIMEOUT LFTP_SETTINGS DEBUG FAIL_ON_DEPRECATED DRY_RUN; do
     _label=$(printf '%s' "${_v}" | tr '[:upper:]' '[:lower:]')
-    eval "_cur=\${INPUT_${_v}}"
+    # Defensive: the `${INPUT_*:-}` default-empty form is needed so
+    # `set -u` (active in this script) does not abort when a variable
+    # is unset. GitHub Actions always exports all declared inputs
+    # (even as empty strings), so this branch is never taken in
+    # production — but it makes the action robust to direct
+    # `docker run` invocations of the image (e.g. for local
+    # debugging, or for the release smoke test in
+    # .github/workflows/release.yml).
+    eval "_cur=\${INPUT_${_v}-}"
     if [ -n "${_cur}" ]; then
       printf '  %-26s (set)\n' "${_label}:"
     else
@@ -241,24 +286,21 @@ echo ""
 #   defaults here before validating. This avoids a false-positive
 #   exit 2 on an empty numeric input.
 # ------------------------------------------------------------------------------
-if [ -z "${INPUT_MAX_RETRIES}" ]; then
-  INPUT_MAX_RETRIES="10"
-fi
-if [ -z "${INPUT_MIRROR_VERBOSE}" ]; then
-  INPUT_MIRROR_VERBOSE="1"
-fi
-if [ -z "${INPUT_FTP_NOP_INTERVAL}" ]; then
-  INPUT_FTP_NOP_INTERVAL="2"
-fi
-if [ -z "${INPUT_NET_MAX_RETRIES}" ]; then
-  INPUT_NET_MAX_RETRIES="1"
-fi
-if [ -z "${INPUT_NET_PERSIST_RETRIES}" ]; then
-  INPUT_NET_PERSIST_RETRIES="5"
-fi
-if [ -z "${INPUT_DNS_MAX_RETRIES}" ]; then
-  INPUT_DNS_MAX_RETRIES="8"
-fi
+# B-07 / smoke-test: normalize all input vars to their effective
+# defaults, then validate. In a real GitHub Actions run these are
+# always populated by the action.yml default, but init.sh can also
+# be run outside that mechanism (tests, manual invocation, the
+# release smoke test against a freshly-built image), so we apply
+# the same defaults here before validating. This avoids a
+# false-positive exit 2 on an empty numeric input AND the
+# 'parameter not set' error that set -u emits when a string input
+# is unset in a direct `docker run` of the image.
+#
+# The defaulting itself is performed by the parameter-expansion
+# block at the top of the script (right after the deprecation
+# check). Here we only validate the integer inputs that have
+# non-empty defaults, since the dump loop and the INPUT_DEBUG
+# check above already need the variables to be defined.
 validate_int "max_retries"         "${INPUT_MAX_RETRIES}"
 validate_int "mirror_verbose"      "${INPUT_MIRROR_VERBOSE}"
 validate_int "ftp_nop_interval"    "${INPUT_FTP_NOP_INTERVAL}"

--- a/tests/release-smoke.sh
+++ b/tests/release-smoke.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# tests/release-smoke.sh — smoke tests run against an already-built
+# ftp-deployment-action image.
+#
+# Used by .github/workflows/release.yml between "Build and push
+# image" and "Generate SBOM" to catch Dockerfile / lftp pin /
+# runtime regressions before the image is signed and the SBOM is
+# attached. Also runnable locally against a freshly-built image.
+#
+# Usage:
+#   tests/release-smoke.sh <image>
+#
+# Where <image> is the image:tag to test (e.g. the value of
+# `steps.meta.outputs.image:${{ steps.meta.outputs.version }}` from
+# the release workflow, or `ftp-deployment-action:local` for a
+# local build).
+#
+# Exit code 0 if all checks pass, non-zero otherwise. The script
+# prints which check failed.
+
+set -eu
+
+IMAGE=${1:-}
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf '  ok: %s\n' "$*"; }
+skip() { printf '  skip: %s\n' "$*"; exit 0; }
+
+# Need an image to test.
+if [ -z "${IMAGE}" ]; then
+  fail "usage: $0 <image:tag>  (e.g. ftp-deployment-action:local)"
+fi
+
+# Need a container runtime.
+if command -v docker >/dev/null 2>&1; then
+  RUNTIME=docker
+elif command -v podman >/dev/null 2>&1; then
+  RUNTIME=podman
+else
+  fail "no docker or podman found on PATH"
+fi
+
+# The smoke tests below each run a container in isolation. They
+# need INPUT_SERVER/INPUT_USER/INPUT_PASSWORD at minimum or
+# init.sh's validation will reject the run for other reasons.
+COMMON_ENV() {
+  printf '%s\n' \
+    "INPUT_SERVER=ftp://127.0.0.1:1" \
+    "INPUT_USER=u" \
+    "INPUT_PASSWORD=p" \
+    "INPUT_MAX_RETRIES=1" \
+    "INPUT_NET_TIMEOUT=2s" \
+    "INPUT_DNS_FATAL_TIMEOUT=2s" \
+    "INPUT_FTP_SSL_ALLOW=false"
+}
+
+# run_in_image ENV_FILE [timeout_seconds]
+# Runs the image with the given env file, returns the exit code.
+# Output is captured to /tmp/smoke-<timestamp>.log; the function
+# returns the exit code and prints the log path on failure.
+run_in_image() {
+  _env=$1
+  _t=${2:-30}
+  _env_file=$(mktemp) || return 1
+  _log=$(mktemp) || return 1
+  {
+    COMMON_ENV
+    printf '%s\n' "${_env}"
+  } > "${_env_file}"
+  _rc=0
+  timeout "${_t}" "${RUNTIME}" run --rm \
+    --env-file "${_env_file}" \
+    "${IMAGE}" >"${_log}" 2>&1 || _rc=$?
+  rm -f "${_env_file}"
+  if [ "${_rc}" -ne 0 ]; then
+    printf 'container output (exit %s):\n' "${_rc}" >&2
+    cat "${_log}" >&2
+    printf 'end of container output.\n' >&2
+  fi
+  rm -f "${_log}"
+  return "${_rc}"
+}
+
+# ---------------------------------------------------------------------------
+# Check 1: the image is pullable / runnable. A simple "validate_path"
+# failure is the cheapest way to verify init.sh executes: pass
+# INPUT_LOCAL_DIR=../etc and expect exit 2.
+#
+# This catches:
+#   * broken ENTRYPOINT in the Dockerfile
+#   * missing init.sh (wrong COPY)
+#   * lftp not installed (apk add failed)
+#   * init.sh syntax error
+#   * a non-root USER that cannot read /app/init.sh
+#   * validate_path itself regressing
+# ---------------------------------------------------------------------------
+echo "=== Check 1: container starts, validate_path rejects '..' (expect exit 2) ==="
+_log=$(mktemp); _env_file=$(mktemp)
+{
+  COMMON_ENV
+  printf 'INPUT_LOCAL_DIR=../etc\n'
+} > "${_env_file}"
+set +e
+timeout 15 "${RUNTIME}" run --rm --env-file "${_env_file}" "${IMAGE}" >"${_log}" 2>&1
+_rc=$?
+set -e
+if [ "${_rc}" -ne 2 ]; then
+  printf 'expected exit 2 (path traversal rejected), got %s\n' "${_rc}" >&2
+  cat "${_log}" >&2
+  rm -f "${_log}" "${_env_file}"
+  fail "INPUT_LOCAL_DIR=../etc did not exit 2"
+fi
+if ! grep -q 'local_dir contains ".." path traversal' "${_log}"; then
+  cat "${_log}" >&2
+  rm -f "${_log}" "${_env_file}"
+  fail "expected the path-traversal error message in the output"
+fi
+rm -f "${_log}" "${_env_file}"
+pass "container runs and validate_path rejects '..' with exit 2"
+
+# ---------------------------------------------------------------------------
+# Check 2: the deprecation warning fires for an EOL ref. We pass
+# GITHUB_ACTION_REF=v1.3.3 (EOL per SECURITY.md) and expect:
+#   * exit 1 (lftp fails on unreachable server after the warning)
+#   * a '::warning file=action.yml,title=End-of-life version::' line
+#
+# This catches:
+#   * _deprecated_check regressing (no ::warning:: emitted)
+#   * the EOL list being accidentally emptied
+#   * the /app/VERSION bake not working (the warning text would
+#     show 'unknown' instead of the real version)
+# ---------------------------------------------------------------------------
+echo "=== Check 2: deprecation warning fires for EOL ref v1.3.3 ==="
+_log=$(mktemp); _env_file=$(mktemp)
+{
+  COMMON_ENV
+  printf 'GITHUB_ACTION_REF=v1.3.3\n'
+} > "${_env_file}"
+set +e
+timeout 60 "${RUNTIME}" run --rm --env-file "${_env_file}" "${IMAGE}" >"${_log}" 2>&1
+_rc=$?
+set -e
+if [ "${_rc}" -ne 1 ]; then
+  cat "${_log}" >&2
+  rm -f "${_log}" "${_env_file}"
+  fail "GITHUB_ACTION_REF=v1.3.3 with unreachable server did not exit 1 (got ${_rc})"
+fi
+if ! grep -q '::warning file=action.yml,title=End-of-life version::' "${_log}"; then
+  cat "${_log}" >&2
+  rm -f "${_log}" "${_env_file}"
+  fail "expected ::warning:: for EOL ref v1.3.3"
+fi
+rm -f "${_log}" "${_env_file}"
+pass "::warning:: emitted for EOL ref v1.3.3"
+
+# ---------------------------------------------------------------------------
+# Check 3: the image prints the right version string. This is the
+# canary that catches the kind of bug that hit v2.3.0: the
+# /app/VERSION file was supposed to be baked at build time with
+# the resolved tag, but if the build-arg wiring regressed the
+# warning text would say 'unknown' instead of the real version.
+#
+# We do this by checking that the warning text in check 2 mentions
+# an image version that is not 'unknown' (i.e. the build-arg
+# actually reached the Dockerfile).
+# ---------------------------------------------------------------------------
+echo "=== Check 3: /app/VERSION is baked (build-arg VERSION reached the Dockerfile) ==="
+_log=$(mktemp); _env_file=$(mktemp)
+{
+  COMMON_ENV
+  printf 'GITHUB_ACTION_REF=v1.3.3\n'
+} > "${_env_file}"
+timeout 60 "${RUNTIME}" run --rm --env-file "${_env_file}" "${IMAGE}" >"${_log}" 2>&1 || true
+# The deprecation warning text mentions '(image version: <v>)'.
+# If the bake worked, <v> is the tag we just cut. If the bake
+# regressed, <v> is the literal string 'unknown' (the fallback
+# in _deprecated_check when /app/VERSION does not exist).
+if grep -q 'image version: unknown' "${_log}"; then
+  cat "${_log}" >&2
+  rm -f "${_log}" "${_env_file}"
+  fail "build-arg VERSION did not reach /app/VERSION; the warning shows 'unknown' as the image version"
+fi
+rm -f "${_log}" "${_env_file}"
+pass "build-arg VERSION was baked into /app/VERSION"
+
+printf '\nAll release smoke tests passed for %s.\n' "${IMAGE}"


### PR DESCRIPTION
Three things, in order of user impact.

### 1. Release smoke test in the pipeline (the original ask)

A new step runs \`tests/release-smoke.sh <just-pushed-image>\`
between *Build and push image* and *Generate SBOM (CycloneDX)*.
The script pulls the just-pushed image from ghcr.io (the
release runner has just logged in, so the auth is in scope)
and runs three cheap checks:

1. The container starts and \`validate_path\` rejects a \`..\`
   in \`local_dir\` (catches: broken ENTRYPOINT, missing
   \`init.sh\`, lftp not installed, \`init.sh\` syntax error,
   a non-root USER that cannot read \`/app/init.sh\`).
2. The deprecation warning fires for an EOL ref (catches:
   \`_deprecated_check\` regressing, the EOL list being
   emptied, the \`GITHUB_ACTION_REF\` plumbing breaking).
3. The \`VERSION\` build-arg was baked into \`/app/VERSION\`
   (catches: \`release.yml\`'s \`build-args\` wiring
   regressing, the Dockerfile losing the \`ARG VERSION\` /
   \`RUN echo\` lines). The warning text would say *image
   version: unknown* otherwise.

The step aborts the release pipeline on any failure. SBOM
generation, cosign signing, and SBOM attestation are skipped
on failure, so we never publish or sign a broken image.

The same script is runnable locally via
\`make release-smoke IMAGE=ftp-deployment-action:local\`. The
Makefile target is documented in a new *Local development*
section in the README.

### 2. Bug found while writing the smoke test (the real value)

The smoke test caught a latent bug in \`init.sh\` that the
existing test suite had been masking: the *Inputs received*
dump block (and the \`if [ \"\${INPUT_DEBUG}\" = 'true' ]\`
check right above it) access the input variables without a
default-empty fallback. With \`set -u\` active, this is fine
in production because the GitHub Actions runner always
exports every declared input (even as empty string). But the
moment you do \`docker run --rm <image>\` directly — which is
exactly what the new smoke test does — none of the inputs
are set and the script dies on line 192 with *INPUT_DEBUG:
parameter not set*.

Fix: a single block of POSIX parameter-expansion defaults at
the top of the script (right after the deprecation check,
before the add-mask and dump blocks):

\`\`\`sh
: \"\${INPUT_SERVER:=\"}
: \"\${INPUT_USER:=\"}
: \"\${INPUT_PASSWORD:=\"}
# ...
: \"\${INPUT_MAX_RETRIES:=10}\"
: \"\${INPUT_MIRROR_VERBOSE:=1}\"
# ...
\`\`\`

This replaces the older \`if [ -z \"\${INPUT_X}\" ] then
INPUT_X=default; fi\` lines for the integer inputs (those
were safe because the older smoke tests always set the
integers, but they would also have failed under \`set -u\`
in a direct \`docker run\`). The defaults for the integer
inputs are now applied via \`:= 10\` etc. so the whole block
is one uniform style and one uniform safety guarantee.

### 3. Drive-by: OCI license label

The \`release.yml\`'s OCI image label was
\`org.opencontainers.image.licenses=GPL-3.0\` from the
original release pipeline. The LICENSE file was re-licensed
to AGPL-3.0 in commit \`f9bfc80\` but the OCI label was not
updated. Bumped to AGPL-3.0.

### Tests

* \`tests/release-smoke.sh\` is new. Validated end-to-end
  against a fresh \`docker build\` of the action image: all
  three checks pass.
* \`make release-smoke IMAGE=<...>\` works locally.
* The existing 26 local smoke tests + contract test still
  pass (init.sh behaviour unchanged for the GitHub Actions
  code path).
* \`shellcheck\` clean on \`init.sh\` and the new test script.
* \`actionlint\` clean on the modified \`release.yml\`.
* \`hadolint\` clean on the unchanged Dockerfile.

### Backward compatibility

The behaviour for callers invoking the action via GitHub
Actions is unchanged: GitHub already exported every declared
input (even as empty string), so the parameter-expansion
defaults just make the script work in the new direct
\`docker run\` case (smoke test, local debugging) without
affecting the production code path.