### PR TITLE
fix(ci): pin sigstore/cosign-installer to a specific version (v4.1.2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,14 @@ updates:
         patterns: ["docker/*"]
       actions-attest:
         patterns: ["actions/attest"]
+      # sigstore/cosign-installer is pinned to a specific version
+      # (v4.1.2) in release.yml because the upstream does not
+      # publish a floating `@v4` git ref; dependabot's default
+      # proposal of `@v4` would fail to resolve at job setup.
+      # Keep the group on a single track so the next bump is a
+      # conscious decision.
+      actions-cosign-installer:
+        patterns: ["sigstore/cosign-installer"]
       actions-others:
         patterns: ["*"]
-        exclude-patterns: ["actions/checkout", "docker/*", "actions/attest"]
+        exclude-patterns: ["actions/checkout", "docker/*", "actions/attest", "sigstore/cosign-installer"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
           path: .
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign image with cosign (keyless, OIDC)
         env:


### PR DESCRIPTION
The v2.4.0 release failed at job setup with:

\`\`\`
##[error]Unable to resolve action \`sigstore/cosign-installer@v4\`,
unable to find version \`v4\`
\`\`\`

PR #62 (Dependabot, merged in commit \`3b8e644\`) bumped from
\`@v3\` to \`@v4\`, but the sigstore/cosign-installer repo
does not publish a floating \`v4\` git ref (it only ships
\`v4.0.0\`, \`v4.1.0\`, \`v4.1.1\`, \`v4.1.2\` etc.).

The smoke test added in PR #63 did not catch this because
the failure is at job setup, before any step runs. The
smoke test in its current form only catches failures between
*Build and push image* and *Generate SBOM*.

### Fix

* Pin to a specific version: \`sigstore/cosign-installer@v4.1.2\`
  (the latest at the time of writing).
* Add a dedicated Dependabot group
  \`actions-cosign-installer\` and exclude \`sigstore/cosign-installer\`
  from the catch-all \`actions-others\` group, so the next
  bump is a conscious decision rather than a silent
  major-version change that may or may not resolve.
  Dependabot will now propose \`v4.1.2\` → \`v4.1.3\` (or
  whatever the next patch is), not \`v4.1.2\` → \`v5\`.

### Backward compatibility

None. The new pin is functionally equivalent to the previous
one for the action's behaviour; the change is in which
release of the upstream is consumed.

### What this is not

This does not bring back the v2.4.0 release. To cut v2.4.0
after this fix lands, just re-tag \`fdb14ad\` as \`v2.4.0\`
(or update the CHANGELOG to roll the fix into a new
\`v2.4.1\` and re-tag). The release pipeline should then
pass on its own (no manual changes needed for the image
itself).