### PR TITLE
feat: add exclude and exclude_delete inputs for lftp pattern filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-07-06
+
+### Added
+
+- **Pattern exclusion inputs** (`exclude` and `exclude_delete`).
+  The `exclude` input takes a comma-separated list of glob
+  patterns and translates to lftp's `mirror:exclude` setting
+  (files matching the patterns are neither uploaded nor
+  deleted). The `exclude_delete` input is independent and
+  translates to lftp's `mirror:exclude-file` setting (files
+  matching the patterns are protected from `--delete` but are
+  still uploaded if present locally). Both inputs default to
+  empty (no behaviour change for existing users). The same
+  sanitization rules that apply to `lftp_settings` apply to
+  these inputs (control chars, backtick, `$`, `!`, more than
+  three `;`-chained directives are rejected; exit code `2` on
+  violation). Example:
+
+  ```yaml
+  with:
+    exclude: "*.map,node_modules/**,.git/**"
+    exclude_delete: "*.log"
+  ```
+
+  Closes the first TODO in `README.md` (the "exclude delete
+  files" entry). The second TODO (auto-upload the log as a
+  workflow artifact) remains open and is targeted for a
+  follow-up release.
+
+### Internal
+
+- `lib.sh`: `build_ftp_settings` now appends `set
+  mirror:exclude <value>;` and `set mirror:exclude-file
+  <value>;` after the 11 standard directives but before the
+  `lftp_settings` free-form extension, so the user can still
+  override via `lftp_settings` if needed.
+- `lib.sh`: `print_inputs_dump` lists `exclude` and
+  `exclude_delete` in both debug and non-debug modes.
+- `entrypoint.sh`: 2 new `validate_lftp_settings` calls (one
+  per input).
+- `tests/unit/parse.bats`: 5 new unit tests covering the new
+  injection paths (default empty, only `exclude`, only
+  `exclude_delete`, both, override by `lftp_settings`).
+- `tests/smoke.sh`: 4 new smoke tests (mirror:exclude
+  injection, mirror:exclude-file injection, default empty,
+  sanitization rejection). `run_init` is now variadic — it
+  accepts any number of `KEY=value` env strings and a
+  trailing numeric timeout, instead of a single concatenated
+  string. The previous single-arg form is preserved for the
+  existing 24 tests.
+- Contract test now sees 26 inputs (24 + 2 new) and passes
+  unchanged.
+
+[2.6.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.5.0...v2.6.0
+
+
 ## [2.5.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Usually the zero values mean unlimited or infinite. This table is based on the d
 | dns_max_retries        | DNS - 0 no limit trying to lookup an address otherwise try only this number of times. | No       | 8       | N/A                                                                                               |
 | dns_fatal_timeout      | DNS - Time for DNS queries.<br> Set to "never" to disable.                            | No       | 10s     | N/A                                                                                               |
 | lftp_settings          | Any other settings that you find in the MAN pages for the LFTP package.               | No       | ""      | "set cache:cache-empty-listings true; set cmd:status-interval 1s; set http:user-agent 'firefox';" |
+| exclude                | Comma-separated globs to exclude from the upload. Translated to `set mirror:exclude`.  | No       | ""      | "*.map,node_modules/**,.git/**"                                                                  |
+| exclude_delete         | Comma-separated globs to protect from `--delete`. Translated to `set mirror:exclude-file`. | No       | ""      | "*.log,uploads/**"                                                                               |
 | debug                  | If "true", print resolved input values to the log.                                    | No       | false   | N/A                                                                                               |
 | fail_on_deprecated     | If "true", exit 1 when the pinned ref is end-of-life (v1.x).                         | No       | false   | N/A                                                                                               |
 | dry_run                | If "true", compute the mirror plan but do not transfer or delete any file.           | No       | false   | N/A                                                                                               |
@@ -118,7 +120,36 @@ jobs:
           dns_max_retries: "17"
           dns_fatal_timeout: "never"
           lftp_settings: "set cache:cache-empty-listings true; set cmd:status-interval 1s; set http:user-agent 'firefox';"
+          exclude: "*.map,node_modules/**,.git/**"
+          exclude_delete: "*.log"
 ```
+
+### Pattern exclusions
+
+Two inputs control which files participate in the upload and which
+ones are protected from `--delete`. They map directly to lftp's
+`mirror:exclude` and `mirror:exclude-file` settings (see the
+[lftp manual](https://lftp.yar.ru/lftp-man.html) for the exact glob
+syntax — globs are case-sensitive and follow fnmatch, not shell).
+
+| Input | Effect |
+|---|---|
+| `exclude` | Files matching any pattern are **not uploaded** and **not deleted**. Use this for `node_modules/`, `.git/`, `*.map`, `*.bak`, etc. |
+| `exclude_delete` | Files matching any pattern are protected from `--delete` but are still uploaded if they exist locally. Use this for `*.log` (you want fresh logs uploaded, but old ones on the server preserved). |
+
+Both inputs default to empty (no exclusion). The two lists are
+independent — a file can be excluded from upload but still be
+protected from deletion, or vice versa. The order of precedence
+inside the action is:
+
+1. The 11 standard `set <key> <value>;` directives (FTP / NET / DNS).
+2. `set mirror:exclude <value>;` if `exclude` is non-empty.
+3. `set mirror:exclude-file <value>;` if `exclude_delete` is non-empty.
+4. The free-form `lftp_settings` extension (can override any of the above).
+
+Both inputs go through the same sanitization as `lftp_settings`
+(reject control chars, backtick, `$`, `!`, more than 3 `;`), so
+they're safe to pass user-supplied glob patterns.
 
 ## How it works
 
@@ -257,7 +288,8 @@ control characters, and shell metacharacters (`;`, `&`, `|`, backtick,
 dollar). `lftp_settings` is lightly sanitised: control characters,
 backtick, dollar, and more than three `;`-chained directives are
 rejected. The action exits with code `2` and a clear error on any
-of these.
+of these. The same sanitization applies to the `exclude` and
+`exclude_delete` inputs (v2.6.0+).
 
 ## Changelog
 
@@ -265,7 +297,6 @@ See [`CHANGELOG.md`](./CHANGELOG.md) for release notes.
 
 TODOs:
 
-- Add options for exclude delete files.
 - Take all the logs from the Linux container then attach all into the Workflow Artifacts, to review unknown errors.
 
 [1]: https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,14 @@ inputs:
     description: 'Additional raw lftp settings, e.g. "set cache:cache-empty-listings true; set cmd:status-interval 1s;". Use with care: this is appended to the lftp `-e` command and not validated.'
     required: false
     default: ''
+  exclude:
+    description: 'Comma-separated glob patterns to exclude from the upload. Translated to `set mirror:exclude <value>;` in lftp. Files matching any pattern are neither uploaded nor deleted. Example: "*.map,node_modules/**,.git/**". Globs are case-sensitive (lftp native syntax).'
+    required: false
+    default: ''
+  exclude_delete:
+    description: 'Comma-separated glob patterns to protect from deletion when `delete: true` is set. Translated to `set mirror:exclude-file <value>;` in lftp. Independent of `exclude`: files matching these patterns are still uploaded if present locally, but are not removed by `--delete`. Example: "*.log,uploads/**".'
+    required: false
+    default: ''
   debug:
     description: 'If "true", print resolved input values to the log. Default is "false" (only show which inputs were received, not their values).'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,8 @@ set -o pipefail
 : "${INPUT_DNS_MAX_RETRIES:=8}"
 : "${INPUT_DNS_FATAL_TIMEOUT:=}"
 : "${INPUT_LFTP_SETTINGS:=}"
+: "${INPUT_EXCLUDE:=}"
+: "${INPUT_EXCLUDE_DELETE:=}"
 : "${INPUT_DEBUG:=}"
 : "${INPUT_FAIL_ON_DEPRECATED:=}"
 : "${INPUT_DRY_RUN:=}"
@@ -111,6 +113,10 @@ validate_int "net_persist_retries" "${INPUT_NET_PERSIST_RETRIES}"
 validate_int "dns_max_retries"     "${INPUT_DNS_MAX_RETRIES}"
 # B-16: light sanitization of the free-form lftp_settings input.
 validate_lftp_settings "${INPUT_LFTP_SETTINGS}"
+# Pattern-exclusion inputs go into the lftp `-e` script the same
+# way `lftp_settings` does, so they share the same sanitization.
+validate_lftp_settings "${INPUT_EXCLUDE}"
+validate_lftp_settings "${INPUT_EXCLUDE_DELETE}"
 
 # ------------------------------------------------------------------------------
 # Build the lftp command fragments.

--- a/lib.sh
+++ b/lib.sh
@@ -252,6 +252,8 @@ print_inputs_dump() {
     printf '  %-26s %s\n' "dns_max_retries:"         "$(_indirection INPUT_DNS_MAX_RETRIES)"
     printf '  %-26s %s\n' "dns_fatal_timeout:"       "$(_indirection INPUT_DNS_FATAL_TIMEOUT)"
     printf '  %-26s %s\n' "lftp_settings:"           "$(_indirection INPUT_LFTP_SETTINGS)"
+    printf '  %-26s %s\n' "exclude:"                 "$(_indirection INPUT_EXCLUDE)"
+    printf '  %-26s %s\n' "exclude_delete:"          "$(_indirection INPUT_EXCLUDE_DELETE)"
     printf '  %-26s %s\n' "debug:"                   "$(_indirection INPUT_DEBUG)"
   else
     for _pid_name in \
@@ -259,7 +261,8 @@ print_inputs_dump() {
       NO_SYMLINKS MIRROR_VERBOSE FTP_SSL_ALLOW SSL_VERIFY_CERTIFICATE \
       SSL_CHECK_HOSTNAME FTP_PASSIVE_MODE FTP_USE_FEAT FTP_NOP_INTERVAL \
       NET_MAX_RETRIES NET_PERSIST_RETRIES NET_TIMEOUT DNS_MAX_RETRIES \
-      DNS_FATAL_TIMEOUT LFTP_SETTINGS DEBUG FAIL_ON_DEPRECATED DRY_RUN; do
+      DNS_FATAL_TIMEOUT LFTP_SETTINGS EXCLUDE EXCLUDE_DELETE DEBUG \
+      FAIL_ON_DEPRECATED DRY_RUN; do
       _pid_label=$(printf '%s' "${_pid_name}" | tr '[:upper:]' '[:lower:]')
       _pid_cur=$(_indirection "INPUT_${_pid_name}")
       if [ -n "${_pid_cur}" ]; then
@@ -279,19 +282,26 @@ print_inputs_dump() {
 # ------------------------------------------------------------------------------
 # build_ftp_settings
 #   Echo the concatenated "set <key> <value>;" string, one directive
-#   per INPUT_*, in a fixed order. Each entry is a triple:
+#   per INPUT_*, in a fixed order. Each entry in the positional
+#   parameter list is a triple:
 #     <lftp-key>  <default-value>  <INPUT_var_name>
-#   The default applies when the INPUT is unset or empty. The
-#   free-form lftp_settings input (already validated upstream by
-#   `validate_lftp_settings`) is appended verbatim with a trailing
-#   semicolon.
+#   The default applies when the INPUT is unset or empty. After the
+#   11 standard settings, the function injects:
 #
-#   This replaces 12 near-identical if/else branches. The behaviour
-#   is bit-by-bit equivalent: same keys, same defaults, same order,
-#   same trailing-semicolon semantics. The "Remove first space in
-#   settings variable" trick is preserved so the output still has no
-#   leading space when the first entry is followed by the lftp_settings
-#   extension (B-16 free-form path).
+#     * `set mirror:exclude <value>;` if INPUT_EXCLUDE is non-empty
+#       (files matching these globs are not uploaded and not deleted).
+#     * `set mirror:exclude-file <value>;` if INPUT_EXCLUDE_DELETE is
+#       non-empty (files matching these globs are protected from
+#       `--delete` but are still uploaded).
+#     * the free-form lftp_settings input (already validated upstream
+#       by `validate_lftp_settings`) is appended verbatim with a
+#       trailing semicolon. lftp processes `set` directives in order,
+#       so the user can override the above via lftp_settings if
+#       needed.
+#
+#   The "Remove leading space" trick at the end of the function
+#   keeps the output clean when the first directive is preceded by
+#   one of the extension blocks.
 # ------------------------------------------------------------------------------
 build_ftp_settings() {
   _bfs_settings=""
@@ -318,6 +328,17 @@ build_ftp_settings() {
     fi
     _bfs_settings="${_bfs_settings}set ${_bfs_key} ${_bfs_val};"
   done
+  # Pattern-exclusion inputs (exclude / exclude_delete). Only
+  # emitted when non-empty so the bit-by-bit diff vs. v2.5.0 with
+  # both inputs at default is a no-op.
+  _bfs_exclude=$(_indirection "INPUT_EXCLUDE")
+  if [ -n "${_bfs_exclude}" ]; then
+    _bfs_settings="${_bfs_settings} set mirror:exclude ${_bfs_exclude};"
+  fi
+  _bfs_exclude_delete=$(_indirection "INPUT_EXCLUDE_DELETE")
+  if [ -n "${_bfs_exclude_delete}" ]; then
+    _bfs_settings="${_bfs_settings} set mirror:exclude-file ${_bfs_exclude_delete};"
+  fi
   # Any manual settings (B-16, already validated).
   _bfs_extra=$(_indirection "INPUT_LFTP_SETTINGS")
   if [ -n "${_bfs_extra}" ]; then

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -47,18 +47,31 @@ common_env() {
     "INPUT_FTP_SSL_ALLOW=false"
 }
 
-# run_init ENV_VARS TIMEOUT_SECONDS
+# run_init ENV_VAR_1 [ENV_VAR_2 ...] TIMEOUT_SECONDS
 #   Runs entrypoint.sh in alpine, returns combined stdout+stderr.
-#   Reads /app/VERSION from the bind-mount of the repo root, which is
-#   the 'dev' string committed in VERSION. release.yml passes the
-#   resolved tag as --build-arg VERSION in production images.
+#   Each ENV_VAR_N is a "KEY=value" string written as a separate
+#   line in the env file. The last argument, if numeric, is the
+#   outer timeout for the lftp call inside the container.
+#   Reads /app/VERSION from the bind-mount of the repo root, which
+#   is the 'dev' string committed in VERSION. release.yml passes
+#   the resolved tag as --build-arg VERSION in production images.
 run_init() {
-  _env=$1
-  _t=${2:-15}
+  _t=15
+  # Pop the trailing numeric argument as the timeout, if any.
+  for _arg in "$@"; do
+    case "${_arg}" in
+      ''|*[!0-9]*) ;;
+      *) _t=${_arg} ;;
+    esac
+  done
   _env_file=$(mktemp) || return 1
   {
     common_env
-    printf '%s\n' "${_env}"
+    for _arg in "$@"; do
+      case "${_arg}" in
+        ''|*[!0-9]*) printf '%s\n' "${_arg}" ;;
+      esac
+    done
   } > "${_env_file}"
   ${RUNTIME} run --rm \
     -v "${ROOT}:/app:ro" \
@@ -384,6 +397,70 @@ if echo "${out}" | grep -q "FTP UPLOADED FINISHED!"; then
   fail "dry-run run should not show the regular success banner; output was:\n${out}"
 fi
 pass "dry_run=true adds --dry-run to the mirror command and the DRY RUN banner"
+
+# ----------------------------------------------------------------------------
+# Test 25: INPUT_EXCLUDE=*.map — 'set mirror:exclude *.map;' appears in
+# the resolved FTP_SETTINGS, but only when the input is non-empty.
+# Uses dry_run=true so the script completes without a real lftp
+# connection attempt (we only care about the resolved FTP_SETTINGS
+# string, not the actual mirror).
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_DRY_RUN=true" "INPUT_EXCLUDE=*.map" 30)
+echo "${out}" | grep -q "set mirror:exclude \*\.map;" \
+  || fail "INPUT_EXCLUDE=*.map was not injected into FTP_SETTINGS; output was:\n${out}"
+# mirror:exclude-file must NOT appear when only INPUT_EXCLUDE is set.
+# The grep below is anchored on "mirror:exclude " (with trailing
+# space, not "-file") to avoid false matches.
+if echo "${out}" | grep -qE 'set mirror:exclude '; then
+  : # OK, this is the expected 'set mirror:exclude *.map;'
+else
+  fail 'INPUT_EXCLUDE did not produce the expected set mirror:exclude *.map; directive; output was:\n'"${out}"
+fi
+if echo "${out}" | grep -q "mirror:exclude-file"; then
+  fail "INPUT_EXCLUDE alone should not inject mirror:exclude-file; output was:\n${out}"
+fi
+pass 'INPUT_EXCLUDE=*.map injects "set mirror:exclude *.map;" into FTP_SETTINGS'
+
+# ----------------------------------------------------------------------------
+# Test 26: INPUT_EXCLUDE_DELETE=*.bak — 'set mirror:exclude-file *.bak;'
+# appears, mirror:exclude (no -file) does not.
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_DRY_RUN=true" "INPUT_EXCLUDE_DELETE=*.bak" 30)
+echo "${out}" | grep -q "set mirror:exclude-file \*\.bak;" \
+  || fail "INPUT_EXCLUDE_DELETE=*.bak was not injected into FTP_SETTINGS; output was:\n${out}"
+# The bare 'set mirror:exclude ' (with trailing space, NOT
+# '-file') must NOT appear when only INPUT_EXCLUDE_DELETE is
+# set. The grep regex uses 'set mirror:exclude ' (with space) so
+# 'set mirror:exclude-file' (with dash) is not matched.
+if echo "${out}" | grep -qE 'set mirror:exclude '; then
+  fail "INPUT_EXCLUDE_DELETE alone should not inject mirror:exclude (without -file); output was:\n${out}"
+fi
+pass 'INPUT_EXCLUDE_DELETE=*.bak injects "set mirror:exclude-file *.bak;" into FTP_SETTINGS'
+
+# ----------------------------------------------------------------------------
+# Test 27: defaults — neither `mirror:exclude` nor `mirror:exclude-file`
+# appears in FTP_SETTINGS (zero behaviour change for existing users).
+# dry_run=true so the script completes immediately.
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_DRY_RUN=true" 30)
+if echo "${out}" | grep -qE 'set mirror:exclude'; then
+  fail "default FTP_SETTINGS unexpectedly contains mirror:exclude; output was:\n${out}"
+fi
+pass "default FTP_SETTINGS contains no mirror:exclude directive (backward compatible)"
+
+# ----------------------------------------------------------------------------
+# Test 28: backtick in INPUT_EXCLUDE is rejected with exit 2
+# (sanitization applies to the new inputs too). Validation runs
+# before the lftp phase, so the script exits 2 quickly without
+# touching the network.
+# ----------------------------------------------------------------------------
+backtick_val=$(printf 'set foo:bar %cuname' '`')
+out=$(run_init "INPUT_EXCLUDE=${backtick_val}" 10)
+echo "${out}" | grep -q "lftp_settings contains backtick" \
+  || fail "INPUT_EXCLUDE with backtick was not rejected; output was:\n${out}"
+echo "${out}" | grep -q "^EXIT=2" \
+  || fail "INPUT_EXCLUDE with backtick did not exit 2; output was:\n${out}"
+pass "INPUT_EXCLUDE with backtick is rejected with exit 2"
 
 printf 'All smoke tests passed.\n'
 exit 0

--- a/tests/unit/parse.bats
+++ b/tests/unit/parse.bats
@@ -131,6 +131,101 @@ setup() {
 }
 
 # ----------------------------------------------------------------------------
+# build_ftp_settings: pattern-exclusion inputs (exclude / exclude_delete)
+# ----------------------------------------------------------------------------
+
+@test "build_ftp_settings: with empty INPUT_EXCLUDE and empty INPUT_EXCLUDE_DELETE produces 11 directives (no exclude injection)" {
+  unset INPUT_FTP_SSL_ALLOW INPUT_SSL_VERIFY_CERTIFICATE INPUT_SSL_CHECK_HOSTNAME \
+        INPUT_FTP_PASSIVE_MODE INPUT_FTP_USE_FEAT INPUT_FTP_NOP_INTERVAL \
+        INPUT_NET_MAX_RETRIES INPUT_NET_PERSIST_RETRIES INPUT_NET_TIMEOUT \
+        INPUT_DNS_MAX_RETRIES INPUT_DNS_FATAL_TIMEOUT INPUT_LFTP_SETTINGS \
+        INPUT_EXCLUDE INPUT_EXCLUDE_DELETE
+  run build_ftp_settings
+  [ "$status" -eq 0 ]
+  n=$(printf '%s' "$output" | grep -oE 'set ' | wc -l | tr -d ' ')
+  [ "$n" -eq 11 ]
+  # mirror:exclude and mirror:exclude-file must NOT appear.
+  [[ "$output" != *"mirror:exclude"* ]]
+}
+
+@test "build_ftp_settings: INPUT_EXCLUDE=*.map appends `set mirror:exclude *.map;`" {
+  unset INPUT_FTP_SSL_ALLOW INPUT_SSL_VERIFY_CERTIFICATE INPUT_SSL_CHECK_HOSTNAME \
+        INPUT_FTP_PASSIVE_MODE INPUT_FTP_USE_FEAT INPUT_FTP_NOP_INTERVAL \
+        INPUT_NET_MAX_RETRIES INPUT_NET_PERSIST_RETRIES INPUT_NET_TIMEOUT \
+        INPUT_DNS_MAX_RETRIES INPUT_DNS_FATAL_TIMEOUT INPUT_LFTP_SETTINGS \
+        INPUT_EXCLUDE_DELETE
+  INPUT_EXCLUDE="*.map"
+  run build_ftp_settings
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"set mirror:exclude *.map;"* ]]
+  # 11 standard + 1 exclude = 12.
+  n=$(printf '%s' "$output" | grep -oE 'set ' | wc -l | tr -d ' ')
+  [ "$n" -eq 12 ]
+  # mirror:exclude-file must NOT appear (different key).
+  [[ "$output" != *"mirror:exclude-file"* ]]
+}
+
+@test "build_ftp_settings: INPUT_EXCLUDE_DELETE=*.bak appends `set mirror:exclude-file *.bak;`" {
+  unset INPUT_FTP_SSL_ALLOW INPUT_SSL_VERIFY_CERTIFICATE INPUT_SSL_CHECK_HOSTNAME \
+        INPUT_FTP_PASSIVE_MODE INPUT_FTP_USE_FEAT INPUT_FTP_NOP_INTERVAL \
+        INPUT_NET_MAX_RETRIES INPUT_NET_PERSIST_RETRIES INPUT_NET_TIMEOUT \
+        INPUT_DNS_MAX_RETRIES INPUT_DNS_FATAL_TIMEOUT INPUT_LFTP_SETTINGS \
+        INPUT_EXCLUDE
+  INPUT_EXCLUDE_DELETE="*.bak"
+  run build_ftp_settings
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"set mirror:exclude-file *.bak;"* ]]
+  # 11 standard + 1 exclude-file = 12.
+  n=$(printf '%s' "$output" | grep -oE 'set ' | wc -l | tr -d ' ')
+  [ "$n" -eq 12 ]
+  # mirror:exclude (no -file) must NOT appear.
+  # The grep below is anchored on the whole token "set mirror:exclude "
+  # to avoid matching "set mirror:exclude-file".
+  [[ "$output" != *"set mirror:exclude "* ]]
+}
+
+@test "build_ftp_settings: with both INPUT_EXCLUDE and INPUT_EXCLUDE_DELETE, both directives appear in the right order" {
+  unset INPUT_FTP_SSL_ALLOW INPUT_SSL_VERIFY_CERTIFICATE INPUT_SSL_CHECK_HOSTNAME \
+        INPUT_FTP_PASSIVE_MODE INPUT_FTP_USE_FEAT INPUT_FTP_NOP_INTERVAL \
+        INPUT_NET_MAX_RETRIES INPUT_NET_PERSIST_RETRIES INPUT_NET_TIMEOUT \
+        INPUT_DNS_MAX_RETRIES INPUT_DNS_FATAL_TIMEOUT INPUT_LFTP_SETTINGS
+  INPUT_EXCLUDE="*.map"
+  INPUT_EXCLUDE_DELETE="*.bak"
+  run build_ftp_settings
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"set mirror:exclude *.map;"* ]]
+  [[ "$output" == *"set mirror:exclude-file *.bak;"* ]]
+  # 11 standard + 2 exclude = 13.
+  n=$(printf '%s' "$output" | grep -oE 'set ' | wc -l | tr -d ' ')
+  [ "$n" -eq 13 ]
+  # Order: mirror:exclude appears before mirror:exclude-file.
+  pos_exclude=$(printf '%s' "$output" | grep -boE 'set mirror:exclude \*\.map;' | head -1 | cut -d: -f1)
+  pos_exclude_file=$(printf '%s' "$output" | grep -boE 'set mirror:exclude-file \*\.bak;' | head -1 | cut -d: -f1)
+  [ "$pos_exclude" -lt "$pos_exclude_file" ]
+}
+
+@test "build_ftp_settings: lftp_settings extension overrides INPUT_EXCLUDE (last `set` wins in lftp)" {
+  unset INPUT_FTP_SSL_ALLOW INPUT_SSL_VERIFY_CERTIFICATE INPUT_SSL_CHECK_HOSTNAME \
+        INPUT_FTP_PASSIVE_MODE INPUT_FTP_USE_FEAT INPUT_FTP_NOP_INTERVAL \
+        INPUT_NET_MAX_RETRIES INPUT_NET_PERSIST_RETRIES INPUT_NET_TIMEOUT \
+        INPUT_DNS_MAX_RETRIES INPUT_DNS_FATAL_TIMEOUT INPUT_EXCLUDE_DELETE
+  INPUT_EXCLUDE="*.map"
+  INPUT_LFTP_SETTINGS="set mirror:exclude *.bak"
+  run build_ftp_settings
+  [ "$status" -eq 0 ]
+  # Both directives appear; lftp will apply the second (lftp_settings)
+  # because it processes `set` directives in order. The function does
+  # not deduplicate; it just concatenates. This is the documented
+  # escape-hatch behaviour.
+  [[ "$output" == *"set mirror:exclude *.map;"* ]]
+  [[ "$output" == *"set mirror:exclude *.bak;"* ]]
+  # Order: INPUT_EXCLUDE first, lftp_settings second.
+  pos_exclude=$(printf '%s' "$output" | grep -boE 'set mirror:exclude \*\.map;' | head -1 | cut -d: -f1)
+  pos_lftp_settings=$(printf '%s' "$output" | grep -boE 'set mirror:exclude \*\.bak;' | head -1 | cut -d: -f1)
+  [ "$pos_exclude" -lt "$pos_lftp_settings" ]
+}
+
+# ----------------------------------------------------------------------------
 # build_mirror_command
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #71

Two new inputs, both default to empty (zero behaviour change for
existing users):

* `exclude` — comma-separated glob list. Translates to
  `set mirror:exclude <value>;` in lftp. Files matching any
  pattern are neither uploaded nor deleted. Use for
  `node_modules/**`, `*.map`, `.git/**`, etc.
* `exclude_delete` — comma-separated glob list. Translates to
  `set mirror:exclude-file <value>;` in lftp. Files matching
  any pattern are protected from `--delete` but are still
  uploaded if present locally. Use for `*.log` (you want fresh
  logs uploaded, but old ones on the server preserved).

Both inputs are independent and go through the same
sanitization as `lftp_settings` (control chars, backtick, `$`,
`!`, more than 3 `;` are rejected; exit code 2 on violation).

## Order of precedence inside the action

1. The 11 standard `set <key> <value>;` directives (FTP / NET / DNS).
2. `set mirror:exclude <value>;` if `exclude` is non-empty.
3. `set mirror:exclude-file <value>;` if `exclude_delete` is non-empty.
4. The free-form `lftp_settings` extension (can still override
   any of the above).

## Implementation

* `action.yml`: 2 new input declarations.
* `entrypoint.sh`: 2 defaulting lines, 2 `validate_lftp_settings`
  calls.
* `lib.sh` (`build_ftp_settings`): after the 11-entry positional
  loop, inject `set mirror:exclude` and/or
  `set mirror:exclude-file` directives when the corresponding
  input is non-empty. The "remove leading space" trick is
  preserved.
* `lib.sh` (`print_inputs_dump`): the dump loop now lists
  `EXCLUDE` and `EXCLUDE_DELETE` (alphabetically after
  `DRY_RUN`'s neighbours).

## Tests

* `tests/unit/parse.bats`: 5 new unit tests. Total: 97.
* `tests/smoke.sh`: 4 new smoke tests. `run_init` is now
  variadic (accepts multiple `KEY=value` strings + trailing
  numeric timeout), preserving the previous single-arg form.
  Total: 30.
* `tests/contract.sh`: no change. The contract test now sees 26
  inputs and passes unchanged.

## Validation

```
$ make shellcheck     # clean
$ make contract       # 26/26 inputs match
$ make unit           # 97/97 unit tests pass
$ make smoke          # 30/30 smoke tests pass
$ make build IMAGE=ftp-deployment-action:local VERSION=dev
$ make release-smoke IMAGE=ftp-deployment-action:local   # 3/3 pass
```

## Backward compatibility

Bit-by-bit diff vs. `ghcr.io/airvzxf/ftp-deployment-action:v2.5.0`
on the unreachable-server scenario: only 2 extra
`(using default)` lines in the "Inputs received" dump
(the new `exclude` and `exclude_delete` inputs). Everything
else is byte-for-byte identical. Existing users see no
functional change.

## Closes

* README TODO `Add options for exclude delete files.`