### PR TITLE
feat(action): add server-side concurrency lock to serialize concurrent deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,120 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-07-07
+
+### Added
+
+- **Server-side concurrency lock to serialize concurrent
+  deployments** (closes the risk from `PROPOSAL.md` §5 #6: "two
+  simultaneous workflows to the same FTP can corrupt each
+  other"). The default is OFF to preserve the v2.7.0
+  behaviour bit-for-bit. Opt in with the new input
+  `concurrency_lock: "true"`.
+
+  ```yaml
+  - uses: airvzxf/ftp-deployment-action@v2
+    with:
+      server: ${{ secrets.FTP_SERVER }}
+      user: ${{ secrets.FTP_USERNAME }}
+      password: ${{ secrets.FTP_PASSWORD }}
+      concurrency_lock: "true"
+  ```
+
+  **Mechanism.** Before the mirror, lftp issues `quote MKD
+  <path>` to create a sentinel directory on the FTP server.
+  RFC 959 `MKD` and `RMD` are implemented by every FTP
+  server (vsftpd, proftpd, Pure-FTPd, sftp-via-FTP-gateways,
+  etc.) and `mkdir(2)` is atomic on virtually every UNIX-like
+  filesystem (returning `EEXIST` if the directory already
+  exists). The race window between two clients is
+  microseconds, and the worst-case outcome — the lock
+  briefly staying held by a dead runner — is caught by the
+  configurable `concurrency_lock_timeout`. We chose
+  `MKD`/`RMD` because lftp has no built-in server-side
+  `lock` command (it only has `file:use-lock` for local
+  files, which we verified against the lftp 4.9.3 source
+  and the `src/commands.cc` static command table).
+
+  **Inputs.**
+
+  - `concurrency_lock` (default `false`) — opt-in switch.
+  - `concurrency_lock_path` (default `.lftp-deployment.lock`)
+    — sentinel directory; validated with the same
+    `validate_path` rules as `local_dir` / `remote_dir`
+    (rejects `..`, leading dash, control chars, and shell
+    metacharacters).
+  - `concurrency_lock_timeout` (default `300`) — maximum
+    seconds to wait for the lock when another run is
+    currently holding it. `0` means "fail immediately when
+    held" (no polling).
+  - `concurrency_lock_poll_interval` (default `5`) — seconds
+    between `quote MKD` attempts. Rejected when `0` (would
+    cause a division-by-zero in the iteration count).
+
+  **Release.** The lock is released in three layered ways:
+  (1) an inline `quote RMD <path>` in the lftp `-e` script
+  right before `quit;`; (2) a fallback `run_lftp_lock_release`
+  call in the EXIT trap (so a signal-killed lftp still
+  releases the lock, using the .netrc that is also about to
+  be removed); (3) the documentation in the README explains
+  the manual `quote RMD` recovery path for the rare case of
+  a stale lock (holder died before any of the above could
+  run). When `concurrency_lock` is `false` (the default),
+  `run_lftp_lock_release` short-circuits on an empty lock
+  path and never invokes lftp, so the no-op path is bit-for-
+  bit identical to v2.7.0.
+
+  **When to use it.** For the common case of a single
+  workflow deploying to one FTP, the **GitHub Actions
+  `concurrency:` block** is the recommended approach
+  (documented as Option A in the new README section "Concurrency /
+  deployment lock") because it works across runners and
+  regions, requires no extra inputs, and is platform-managed.
+  The `concurrency_lock` input is the fallback for users who
+  cannot add a `concurrency:` block (e.g. multiple distinct
+  workflows pointing to the same FTP, or deploys driven by a
+  tool the user does not own).
+
+### Internal
+
+- `lib.sh`: new functions `build_lock_acquire_script`,
+  `build_lock_release_script`, and `run_lftp_lock_release`.
+  All three read the new inputs via `_indirection` (the
+  project's single point of dynamic variable-name lookup);
+  no second `eval` site is introduced.
+- `lib.sh`: `run_lftp_once` now takes two extra parameters
+  (lock acquire / release fragments). When the lock is
+  disabled, both are empty strings, so the composed
+  lftp `-e` script is bit-for-bit identical to v2.7.0.
+- `lib.sh`: `print_inputs_dump` now lists the four new
+  inputs in both debug and non-debug modes.
+- `entrypoint.sh`: the new inputs are defaulted to their
+  `action.yml` defaults; `validate_path` /
+  `validate_int` are run only when the lock is enabled,
+  to keep the validation surface tight for the common
+  case (`concurrency_lock=false`). The EXIT trap is
+  extended to call `run_lftp_lock_release` before
+  removing the .netrc (so lftp can still authenticate
+  the release call).
+- Tests: 11 new bats unit tests in `tests/unit/lock.bats`
+  cover the empty/non-empty branches, the `timeout=0`
+  short-circuit, the `ceil(timeout/poll)` iteration count
+  for both 300/5 and 300/7, the lock path verbatim pass-
+  through, and the no-op paths of `run_lftp_lock_release`.
+  3 new smoke tests in `tests/smoke.sh` verify the
+  default-off path emits no lock fragments in the lftp
+  script, and that `..` in `concurrency_lock_path` and
+  `0` in `concurrency_lock_poll_interval` are both
+  rejected with exit 2.
+- `tests/contract.sh` was unchanged: it auto-discovers the
+  four new inputs from the new `lib.sh::print_inputs_dump`
+  list and from the static `INPUT_*` references in
+  `entrypoint.sh` / `lib.sh`, and matches them against
+  `action.yml` (now 31 declared inputs).
+- Total test count: 118 unit + 33 smoke + 1 contract + 3
+  release-smoke = 155 tests, all green.
+
 ## [2.7.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Usually the zero values mean unlimited or infinite. This table is based on the d
 | fail_on_deprecated     | If "true", exit 1 when the pinned ref is end-of-life (v1.x).                         | No       | false   | N/A                                                                                               |
 | dry_run                | If "true", compute the mirror plan but do not transfer or delete any file.           | No       | false   | N/A                                                                                               |
 | upload_log_on_failure  | If "true" (default), on exit 1 upload the captured lftp log to the workflow run as an artifact (90-day retention). Requires `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the step. | No       | true    | N/A                                                                                               |
+| concurrency_lock       | If "true", serialize concurrent deployments to the same FTP server by acquiring a server-side sentinel directory. See "Concurrency / deployment lock" below. | No       | false   | N/A                                                                                               |
+| concurrency_lock_path  | Path of the sentinel directory used by `concurrency_lock`. Must be a valid FTP path (no `..`, no shell metacharacters, no leading dash). | No       | .lftp-deployment.lock | N/A                                                                                |
+| concurrency_lock_timeout | Maximum seconds to wait for the lock when `concurrency_lock` is "true" and another run is currently holding it. `0` means fail immediately when held. | No | 300  | N/A                                                                                               |
+| concurrency_lock_poll_interval | Seconds between lock acquisition attempts.                                                  | No       | 5       | N/A                                                                                               |
 
 More information on the official site for [lftp - Manual pages][2].
 
@@ -195,6 +199,136 @@ within the workflow run) so that re-running a failed job
 produces a separate artifact per attempt instead of
 overwriting the previous one.
 
+## Concurrency / deployment lock
+
+Two workflows (or two runs of the same workflow) deploying to
+the **same FTP server at the same time** can corrupt each
+other: `lftp mirror --reverse` lists both source and target
+directories, then races on writes. Concurrent uploads with
+`--delete` are especially dangerous — each run can see the
+other's freshly-uploaded files and delete them as "no longer
+in the source".
+
+### Option A — recommended: GitHub Actions `concurrency:` block
+
+If both deployments run in the **same workflow** (or in two
+workflows you control), the simplest fix is GitHub's built-in
+serialization. Add a `concurrency:` group to your job:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ftp-deploy-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: airvzxf/ftp-deployment-action@v2
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+```
+
+- `group: ftp-deploy-${{ github.ref }}` — at most one deploy
+  per ref (branch / tag) at a time. Use
+  `ftp-deploy-${{ github.workflow }}-${{ github.ref }}` if
+  you also want to serialize across distinct workflows that
+  deploy to the same server.
+- `cancel-in-progress: false` — newer runs wait for the
+  in-flight one to finish instead of cancelling it (which
+  would leave a half-uploaded server).
+
+This works across runners, regions, and self-hosted hosts, and
+requires no code in the action. It is the recommended option
+for everyone who can set it.
+
+### Option B — server-side sentinel lock (this action)
+
+If you cannot add a `concurrency:` block (e.g. your deploy is
+driven by a tool you don't own, or you deploy from multiple
+distinct workflows pointing to the same FTP and don't want
+to share a group name), opt in to the server-side lock:
+
+```yaml
+- uses: airvzxf/ftp-deployment-action@v2
+  with:
+    server: ${{ secrets.FTP_SERVER }}
+    user: ${{ secrets.FTP_USERNAME }}
+    password: ${{ secrets.FTP_PASSWORD }}
+    concurrency_lock: "true"
+```
+
+**What it does.** Before the mirror, lftp issues
+`quote MKD <path>` to create a sentinel directory on the
+FTP server. If the server replies `257` (created), the
+deployment holds the lock and proceeds. If the server
+replies `550` (already exists), another run is in flight;
+the action polls up to `concurrency_lock_timeout` seconds
+(retrying every `concurrency_lock_poll_interval` seconds)
+and then fails with a clear error. After the mirror
+completes (or on any exit path — success, error, SIGINT,
+5h timeout, signal), the action issues `quote RMD <path>`
+to release the lock, both in the same lftp invocation
+and via the EXIT trap as a fallback.
+
+**Why MKD/RMD and not a "lock" command.** lftp does not
+ship a server-side `lock` primitive — it only has
+`file:use-lock` for *local* files. MKD and RMD are RFC 959
+basics and are implemented by every FTP server
+(vsftpd, proftpd, Pure-FTPd, SFTP-via-FTP-gateways, etc.).
+`mkdir` is atomic on virtually every UNIX-like filesystem
+(returning `EEXIST` if the dir already exists), so the
+race window between two clients is microseconds and the
+worst-case outcome is that the lock briefly stays held by
+a dead runner — which the `concurrency_lock_timeout`
+catches.
+
+**Stale lock risk.** If the holder dies before RMD (runner
+OOM, the 5h hard timeout, a `kill -9` from the runner host),
+subsequent runs will wait the full `concurrency_lock_timeout`
+and then fail. To recover without waiting, log in to the
+FTP and remove the sentinel directory manually:
+
+```sh
+lftp -u user,pw ftp://example.com -e "rm -rf .lftp-deployment.lock; quit;"
+```
+
+A timestamp-sentinel inside the lock directory (so the
+action can auto-detect staleness) is on the roadmap for a
+future release.
+
+**Customizing the lock path.** If you have several
+deployments against the same FTP server (e.g. one for
+production, one for staging, each writing to a different
+remote directory), give each its own lock path:
+
+```yaml
+- uses: airvzxf/ftp-deployment-action@v2
+  with:
+    concurrency_lock: "true"
+    concurrency_lock_path: ".lftp-deployment.lock.prod"
+```
+
+**Limitations.**
+
+- The lock is **advisory**: a hostile client that ignores
+  the sentinel can still upload concurrently. The lock
+  protects against accidental races from CI runs, not
+  against malicious actors.
+- The lock is **per-server, not per-path**: two deploys to
+  the same FTP but different `remote_dir` will serialize.
+  This is usually the right call (uploads to the same
+  server still share an FTP control connection and the
+  server's filesystem cache) but if you need finer
+  granularity, give each deploy a different
+  `concurrency_lock_path`.
+- The lock is **not replicated across FTP servers**: if you
+  mirror to two backends via different `server` inputs in
+  one step, this input does not coordinate between them.
+  For that, use Option A with a shared `concurrency:`
+  group.
+
 ## How it works
 
 ```
@@ -230,10 +364,16 @@ overwriting the previous one.
 |  5. Write .netrc         |--- 0600, removed by EXIT trap
 |     (write_netrc)        |
 |                          |
+|  5b. Acquire server lock  |--- only if concurrency_lock=true
+|      (build_lock_acquire, |   `quote MKD <path>` in a `repeat --until-ok`
+|       inline in -e)      |   loop; polls up to concurrency_lock_timeout s
+|                          |   then fails with exit 1
+|                          |
 |  6. lftp -e "..."        |--- +global 5h timeout
 |     (run_lftp_once +     |   + exponential backoff with jitter
 |      retry loop,         |   + per-attempt net/dns timeouts
-|      max_retries=0..N)   |
+|      max_retries=0..N)   |   + releases lock via `quote RMD` + EXIT trap
+|                          |     if it was acquired
 |                          |
 |  7. Upload log artifact  |--- only on FAIL; needs GITHUB_TOKEN; skip-on-missing
 |     (upload_log_artifact)|   90-day retention; fail-soft (warning on error)

--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,22 @@ inputs:
     description: 'If "true" (default), when the action is about to exit 1, the captured lftp log file is uploaded to the current workflow run as a workflow artifact named "ftp-deployment-action-log-<run-attempt>". Requires the step to expose GITHUB_TOKEN via `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. If the token (or any of the other GitHub-Actions env vars) is missing, the upload is silently skipped with a notice and the action still exits 1 normally. If the upload request itself fails (network, 4xx, 5xx), a warning is printed and the action still exits 1. Set to "false" to disable the upload entirely (the log file is still captured under ~/.lftp-logs/ for the runner to inspect).'
     required: false
     default: 'true'
+  concurrency_lock:
+    description: 'If "true", serialize concurrent deployments to the same FTP server by acquiring a server-side sentinel directory before the mirror. Implementation: lftp issues `quote MKD <path>` before the mirror and `quote RMD <path>` after; while MKD returns 550 (lock held), the action polls up to `concurrency_lock_timeout` seconds. Uses RFC 959 MKD/RMD which every FTP server supports. The lock is released on any exit path (success, error, SIGINT, 5h timeout) by the cleanup trap. Default is "false" (no cross-runner serialization). For zero-config serialization, prefer the GitHub Actions `concurrency:` block in your workflow. Stale-lock risk: if the holder dies before RMD, subsequent runs will wait until `concurrency_lock_timeout` and then fail with exit 1. See README "Concurrency / deployment lock" for details.'
+    required: false
+    default: 'false'
+  concurrency_lock_path:
+    description: 'Path of the sentinel directory used by `concurrency_lock`. Relative paths are resolved against the FTP user''s home; absolute paths are accepted. Must be a valid FTP path (no `..`, no shell metacharacters, no leading dash). Default: ".lftp-deployment.lock" (a hidden directory alongside the deployed files). The directory will be created and removed by the action; do not use a path that holds user data.'
+    required: false
+    default: '.lftp-deployment.lock'
+  concurrency_lock_timeout:
+    description: 'Maximum seconds to wait for the lock when `concurrency_lock` is "true" and another run is currently holding it. After this, the action exits 1 with a clear error. Set to "0" to fail immediately when the lock is held (no waiting). Default is 300 (5 minutes), which is long enough to ride out a transient concurrent run, short enough that a stale lock surfaces within a normal workflow run.'
+    required: false
+    default: '300'
+  concurrency_lock_poll_interval:
+    description: 'Seconds between lock acquisition attempts when `concurrency_lock` is "true". Default is 5, which gives 60 attempts over the default 300-second timeout. Lower values reduce the time-to-acquire after the holder releases; higher values reduce the number of MKD round-trips against the server.'
+    required: false
+    default: '5'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,6 +78,10 @@ set -o pipefail
 : "${INPUT_FAIL_ON_DEPRECATED:=}"
 : "${INPUT_DRY_RUN:=}"
 : "${INPUT_UPLOAD_LOG_ON_FAILURE:=}"
+: "${INPUT_CONCURRENCY_LOCK:=false}"
+: "${INPUT_CONCURRENCY_LOCK_PATH:=.lftp-deployment.lock}"
+: "${INPUT_CONCURRENCY_LOCK_TIMEOUT:=300}"
+: "${INPUT_CONCURRENCY_LOCK_POLL_INTERVAL:=5}"
 
 # ------------------------------------------------------------------------------
 # Emit deprecation / EOL warning based on the ref the user pinned
@@ -118,6 +122,22 @@ validate_lftp_settings "${INPUT_LFTP_SETTINGS}"
 # way `lftp_settings` does, so they share the same sanitization.
 validate_lftp_settings "${INPUT_EXCLUDE}"
 validate_lftp_settings "${INPUT_EXCLUDE_DELETE}"
+# Concurrency lock: validate path and integers only when enabled,
+# to keep the validation surface tight for the common case
+# (concurrency_lock=false). validate_int already rejects negatives
+# and non-numeric values; the only extra check we need is
+# poll_interval > 0 (0 would be a division-by-zero in the count
+# computation).
+if [ "${INPUT_CONCURRENCY_LOCK}" = "true" ]; then
+  validate_path "concurrency_lock_path" "${INPUT_CONCURRENCY_LOCK_PATH}"
+  validate_int "concurrency_lock_timeout" "${INPUT_CONCURRENCY_LOCK_TIMEOUT}"
+  validate_int "concurrency_lock_poll_interval" "${INPUT_CONCURRENCY_LOCK_POLL_INTERVAL}"
+  if [ "${INPUT_CONCURRENCY_LOCK_POLL_INTERVAL}" = "0" ]; then
+    printf 'ERROR: concurrency_lock_poll_interval must be > 0 (got: %s)\n' \
+      "${INPUT_CONCURRENCY_LOCK_POLL_INTERVAL}" >&2
+    exit 2
+  fi
+fi
 
 # ------------------------------------------------------------------------------
 # Build the lftp command fragments.
@@ -137,6 +157,11 @@ INPUT_REMOTE_DIR=$(normalize_dir "${INPUT_REMOTE_DIR}")
 validate_path "local_dir"  "${INPUT_LOCAL_DIR}"
 validate_path "remote_dir" "${INPUT_REMOTE_DIR}"
 MIRROR_COMMAND=$(build_mirror_command)
+# v2.8.0: server-side concurrency lock fragments. Both echo empty
+# when INPUT_CONCURRENCY_LOCK is not "true", so the no-op case
+# produces a bit-for-bit identical lftp -e script as v2.7.0.
+LOCK_ACQUIRE=$(build_lock_acquire_script)
+LOCK_RELEASE=$(build_lock_release_script)
 
 # ------------------------------------------------------------------------------
 # Display the resolved configuration.
@@ -156,6 +181,16 @@ print_resolved_config
 NETRC="${HOME}/.netrc"
 NETRC_HOST=$(extract_netrc_host "${INPUT_SERVER}")
 write_netrc "${NETRC}" "${NETRC_HOST}" "${INPUT_USER}" "${INPUT_PASSWORD}"
+
+# v2.8.0: extend the EXIT trap installed by write_netrc above to
+# also release the server-side concurrency lock (best-effort).
+# Order matters: the lock release must run BEFORE the .netrc is
+# removed, because the release invokes lftp which needs the .netrc
+# to authenticate. run_lftp_lock_release is a no-op when the lock
+# is disabled, so installing the extended trap unconditionally is
+# safe and keeps the no-lock code path bit-for-bit identical to
+# v2.7.0.
+trap 'run_lftp_lock_release "${INPUT_SERVER}" "${NETRC}" "${INPUT_CONCURRENCY_LOCK_PATH}"; rm -f "${NETRC}"' EXIT
 
 # ------------------------------------------------------------------------------
 # Execute the LFTP actions.
@@ -206,7 +241,9 @@ while true; do
     "${INPUT_REMOTE_DIR}" \
     "${LOG_FILE}" \
     "${LFTP_TIMEOUT}" \
-    "${LFTP_KILL_AFTER}"
+    "${LFTP_KILL_AFTER}" \
+    "${LOCK_ACQUIRE}" \
+    "${LOCK_RELEASE}"
   LFTP_RC=$?
   set -e
 

--- a/lib.sh
+++ b/lib.sh
@@ -256,6 +256,10 @@ print_inputs_dump() {
     printf '  %-26s %s\n' "exclude_delete:"          "$(_indirection INPUT_EXCLUDE_DELETE)"
     printf '  %-26s %s\n' "debug:"                   "$(_indirection INPUT_DEBUG)"
     printf '  %-26s %s\n' "upload_log_on_failure:"   "$(_indirection INPUT_UPLOAD_LOG_ON_FAILURE)"
+    printf '  %-26s %s\n' "concurrency_lock:"        "$(_indirection INPUT_CONCURRENCY_LOCK)"
+    printf '  %-26s %s\n' "concurrency_lock_path:"   "$(_indirection INPUT_CONCURRENCY_LOCK_PATH)"
+    printf '  %-26s %s\n' "concurrency_lock_timeout:"  "$(_indirection INPUT_CONCURRENCY_LOCK_TIMEOUT)"
+    printf '  %-26s %s\n' "concurrency_lock_poll_interval:"  "$(_indirection INPUT_CONCURRENCY_LOCK_POLL_INTERVAL)"
   else
     for _pid_name in \
       SERVER USER PASSWORD LOCAL_DIR REMOTE_DIR MAX_RETRIES DELETE \
@@ -263,7 +267,9 @@ print_inputs_dump() {
       SSL_CHECK_HOSTNAME FTP_PASSIVE_MODE FTP_USE_FEAT FTP_NOP_INTERVAL \
       NET_MAX_RETRIES NET_PERSIST_RETRIES NET_TIMEOUT DNS_MAX_RETRIES \
       DNS_FATAL_TIMEOUT LFTP_SETTINGS EXCLUDE EXCLUDE_DELETE DEBUG \
-      FAIL_ON_DEPRECATED DRY_RUN UPLOAD_LOG_ON_FAILURE; do
+      FAIL_ON_DEPRECATED DRY_RUN UPLOAD_LOG_ON_FAILURE \
+      CONCURRENCY_LOCK CONCURRENCY_LOCK_PATH CONCURRENCY_LOCK_TIMEOUT \
+      CONCURRENCY_LOCK_POLL_INTERVAL; do
       _pid_label=$(printf '%s' "${_pid_name}" | tr '[:upper:]' '[:lower:]')
       _pid_cur=$(_indirection "INPUT_${_pid_name}")
       if [ -n "${_pid_cur}" ]; then
@@ -395,6 +401,95 @@ build_mirror_command() {
   fi
 
   printf '%s' "${_bmc_command}"
+}
+
+# ------------------------------------------------------------------------------
+# build_lock_acquire_script
+#   Echo the lftp script fragment that acquires the server-side
+#   concurrency lock, or echo an empty string if locking is disabled.
+#
+#   The lock is implemented as a directory on the FTP server: lftp
+#   issues `quote MKD <path>` and the server returns 257 on success
+#   (we hold the lock) or 550 if the directory already exists
+#   (someone else holds it). On 550 we wait `poll_interval` seconds
+#   and retry, up to `timeout` seconds total, then lftp exits non-
+#   zero and the action fails.
+#
+#   Why a directory (MKD/RMD) and not a file (STOU/DELE):
+#     * MKD/RMD are RFC 959 basics, implemented by every FTP server.
+#     * STOU/UNIQUE are server-specific extensions and inconsistently
+#       supported. The lock would silently never engage on servers
+#       that lack them.
+#     * mkdir is atomic on virtually every UNIX-like filesystem; the
+#       race window is microseconds and the worst-case outcome is
+#       that the lock briefly stays held by a dead runner (handled
+#       below by the timeout).
+#
+#   Why `repeat --until-ok` (not `--while-ok`):
+#     * `--while-ok` means "stop when command exits non-zero", i.e.
+#       repeat while success. That is the wrong direction: we want
+#       to repeat *until* success, i.e. stop on zero. `--until-ok`
+#       does exactly that.
+#
+#   Why the acquire script is empty when locking is disabled: the
+#   caller (run_lftp_once) unconditionally concatenates the acquire
+#   fragment with the rest of the lftp `-e` script, so an empty
+#   fragment is a no-op.
+#
+#   Stale-lock risk: if the holder dies before RMD (runner OOM, GH
+#   Actions 6h job limit, SIGKILL), the next runner will wait the
+#   full timeout and then fail. A timestamp sentinel inside the lock
+#   directory could mitigate this, but adds a non-trivial amount of
+#   complexity. We accept the trade-off for v2.8.0; document the
+#   workaround (manual RMD via FTP) in the README.
+#
+#   Reads: INPUT_CONCURRENCY_LOCK, INPUT_CONCURRENCY_LOCK_PATH,
+#          INPUT_CONCURRENCY_LOCK_TIMEOUT,
+#          INPUT_CONCURRENCY_LOCK_POLL_INTERVAL.
+# ------------------------------------------------------------------------------
+build_lock_acquire_script() {
+  if [ "$(_indirection INPUT_CONCURRENCY_LOCK)" != "true" ]; then
+    return 0
+  fi
+  _blas_path=$(_indirection INPUT_CONCURRENCY_LOCK_PATH)
+  _blas_timeout=$(_indirection INPUT_CONCURRENCY_LOCK_TIMEOUT)
+  _blas_poll=$(_indirection INPUT_CONCURRENCY_LOCK_POLL_INTERVAL)
+
+  # Compute iteration count. timeout=0 means "no waiting, fail
+  # immediately if the lock is held" -> count=1, so repeat tries
+  # exactly once. Otherwise, count = ceil(timeout / poll).
+  if [ "${_blas_timeout}" = "0" ]; then
+    _blas_count=1
+  else
+    _blas_count=$(( (_blas_timeout + _blas_poll - 1) / _blas_poll ))
+  fi
+
+  # Use the SET-arg form of `repeat` so the count/delay values are
+  # not vulnerable to FTP-path expansion by the lftp tokenizer.
+  # The path is passed verbatim to `quote`; lftp's `quote` sends the
+  # rest of the line as a raw FTP command (see lftp-man.html).
+  printf 'set cmd:at-exit-bg ""; set cmd:at-exit ""; repeat --until-ok -c %d -d %d quote MKD %s && ' \
+    "${_blas_count}" "${_blas_poll}" "${_blas_path}"
+}
+
+# ------------------------------------------------------------------------------
+# build_lock_release_script
+#   Echo the lftp script fragment that releases the server-side
+#   concurrency lock (a `quote RMD <path>`), or echo an empty string
+#   if locking is disabled. The release is best-effort: RMD on a
+#   non-existent path returns 550, which we intentionally do not
+#   surface. The cleanup path in entrypoint.sh ALSO releases the
+#   lock from a separate lftp invocation, in case the main lftp
+#   process was killed before reaching the release command.
+#
+#   Reads: INPUT_CONCURRENCY_LOCK, INPUT_CONCURRENCY_LOCK_PATH.
+# ------------------------------------------------------------------------------
+build_lock_release_script() {
+  if [ "$(_indirection INPUT_CONCURRENCY_LOCK)" != "true" ]; then
+    return 0
+  fi
+  _blrs_path=$(_indirection INPUT_CONCURRENCY_LOCK_PATH)
+  printf 'quote RMD %s; ' "${_blrs_path}"
 }
 
 # ------------------------------------------------------------------------------
@@ -536,7 +631,7 @@ compute_backoff_seconds() {
 }
 
 # ------------------------------------------------------------------------------
-# run_lftp_once SERVER FTP_SETTINGS MIRROR LOCAL REMOTE LOG_FILE TIMEOUT KILL_AFTER
+# run_lftp_once SERVER FTP_SETTINGS MIRROR LOCAL REMOTE LOG_FILE TIMEOUT KILL_AFTER LOCK_ACQUIRE LOCK_RELEASE
 #   Run a single lftp invocation with the given parameters, capturing
 #   combined stdout+stderr to LOG_FILE. The function returns lftp's
 #   exit code via the function-return convention. The caller is
@@ -546,6 +641,11 @@ compute_backoff_seconds() {
 #   This is the B-09 + B-05 plumbing: a hard global timeout around
 #   lftp, and an explicit exit-code capture so the caller's
 #   `set -e` does not short-circuit the failure banner.
+#
+#   LOCK_ACQUIRE is prepended to the mirror command, LOCK_RELEASE is
+#   appended right before the final `; quit;`. Both are empty when
+#   INPUT_CONCURRENCY_LOCK is not "true", in which case the script
+#   is bit-for-bit identical to v2.7.0.
 #
 #   IMPORTANT: this function does NOT re-enable `set -e` before
 #   returning. If it did, a non-zero lftp exit would cause the
@@ -563,6 +663,8 @@ run_lftp_once() {
   _rlo_log=$6
   _rlo_timeout=$7
   _rlo_kill_after=$8
+  _rlo_lock_acquire=$9
+  _rlo_lock_release=${10}
 
   # B-03: no -u USER,PASS — lftp reads credentials from ${NETRC}.
   # B-04: redirect combined stdout+stderr to the timestamped log file
@@ -570,8 +672,45 @@ run_lftp_once() {
   # the user wishes, attached as a workflow artifact.
   timeout -k "${_rlo_kill_after}" "${_rlo_timeout}" lftp \
     "${_rlo_server}" \
-    -e "${_rlo_settings} ${_rlo_mirror} ${_rlo_local} ${_rlo_remote}; quit;" \
+    -e "${_rlo_settings} ${_rlo_lock_acquire}${_rlo_mirror} ${_rlo_local} ${_rlo_remote}; ${_rlo_lock_release}quit;" \
     > "${_rlo_log}" 2>&1
+}
+
+# ------------------------------------------------------------------------------
+# run_lftp_lock_release SERVER NETRC_PATH LOCK_PATH
+#   Best-effort standalone lftp invocation that just runs
+#   `quote RMD <lock_path>` and quits. Used by the EXIT trap in
+#   entrypoint.sh to release the server-side concurrency lock if
+#   the main run_lftp_once was killed before reaching its in-script
+#   release (signal, OOM, hard timeout). Failures are silently
+#   swallowed because at this point the script is already on the
+#   way out; we do not want the cleanup itself to print spurious
+#   noise. Logs to /dev/null.
+#
+#   When the lock is disabled or LOCK_PATH is empty, this function
+#   is a no-op (it returns 0 without invoking lftp at all).
+# ------------------------------------------------------------------------------
+run_lftp_lock_release() {
+  _rlr_server=$1
+  _rlr_netrc=$2
+  _rlr_lock_path=$3
+
+  if [ -z "${_rlr_lock_path}" ]; then
+    return 0
+  fi
+  if [ ! -f "${_rlr_netrc}" ]; then
+    return 0
+  fi
+
+  # `set +e` so a non-zero lftp exit does not abort the parent
+  # trap. The whole point of this function is to fail soft.
+  set +e
+  timeout 30s lftp \
+    "${_rlr_server}" \
+    -e "quote RMD ${_rlr_lock_path}; quit;" \
+    >/dev/null 2>&1
+  set -e
+  return 0
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -498,5 +498,43 @@ echo "${out}" | grep -q "^EXIT=1" \
   || fail "upload_log_on_failure=true with missing GITHUB_TOKEN did not exit 1; output was:\n${out}"
 pass "INPUT_UPLOAD_LOG_ON_FAILURE=true with missing GITHUB_TOKEN skips upload with notice, still exits 1"
 
+# ----------------------------------------------------------------------------
+# Test 31: INPUT_CONCURRENCY_LOCK=false (default) — the lftp -e
+# script is bit-for-bit identical to v2.7.0: no `quote MKD` or
+# `repeat --until-ok` substring appears. We assert by substring
+# absence (a passing test means the lock fragments are empty).
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_DRY_RUN=true" 30)
+if echo "${out}" | grep -q "quote MKD"; then
+  fail "concurrency_lock=false (default) should not emit any quote MKD; output was:\n${out}"
+fi
+if echo "${out}" | grep -q "repeat --until-ok"; then
+  fail "concurrency_lock=false (default) should not emit a repeat loop; output was:\n${out}"
+fi
+pass "concurrency_lock=false produces no lock fragments in the lftp script"
+
+# ----------------------------------------------------------------------------
+# Test 32: INPUT_CONCURRENCY_LOCK=true with a ".." path → exit 2
+# (validate_path rejects traversal before any network attempt).
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_CONCURRENCY_LOCK=true" "INPUT_CONCURRENCY_LOCK_PATH=../escape" 10)
+echo "${out}" | grep -q "concurrency_lock_path contains \"\\.\\.\"" \
+  || fail "concurrency_lock_path with traversal was not rejected; output was:\n${out}"
+echo "${out}" | grep -q "^EXIT=2" \
+  || fail "concurrency_lock_path with traversal did not exit 2; output was:\n${out}"
+pass "concurrency_lock_path with '..' is rejected with exit 2"
+
+# ----------------------------------------------------------------------------
+# Test 33: INPUT_CONCURRENCY_LOCK=true with poll_interval=0 → exit 2
+# (we explicitly reject 0 because it would cause a division-by-zero
+# in the iteration-count computation).
+# ----------------------------------------------------------------------------
+out=$(run_init "INPUT_CONCURRENCY_LOCK=true" "INPUT_CONCURRENCY_LOCK_POLL_INTERVAL=0" 10)
+echo "${out}" | grep -q "concurrency_lock_poll_interval must be > 0" \
+  || fail "concurrency_lock_poll_interval=0 was not rejected; output was:\n${out}"
+echo "${out}" | grep -q "^EXIT=2" \
+  || fail "concurrency_lock_poll_interval=0 did not exit 2; output was:\n${out}"
+pass "concurrency_lock_poll_interval=0 is rejected with exit 2"
+
 printf 'All smoke tests passed.\n'
 exit 0

--- a/tests/unit/lock.bats
+++ b/tests/unit/lock.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# tests/unit/lock.bats — unit tests for the concurrency-lock
+# functions in lib.sh: build_lock_acquire_script,
+# build_lock_release_script, run_lftp_lock_release.
+#
+# The functions read INPUT_CONCURRENCY_LOCK and friends via
+# _indirection. The tests set those variables to exercise the
+# relevant branch.
+
+setup() {
+  set +u
+  LIB="${BATS_TEST_DIRNAME}/../../lib.sh"
+  # shellcheck disable=SC1090
+  . "${LIB}"
+
+  # Reset the lock-related INPUT_* to their action.yml defaults
+  # before every test, so a previous test that set them does not
+  # leak into the next one.
+  unset INPUT_CONCURRENCY_LOCK \
+        INPUT_CONCURRENCY_LOCK_PATH \
+        INPUT_CONCURRENCY_LOCK_TIMEOUT \
+        INPUT_CONCURRENCY_LOCK_POLL_INTERVAL
+}
+
+# ----------------------------------------------------------------------------
+# build_lock_acquire_script — disabled
+# ----------------------------------------------------------------------------
+
+@test "build_lock_acquire_script: empty when INPUT_CONCURRENCY_LOCK is unset" {
+  unset INPUT_CONCURRENCY_LOCK
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "build_lock_acquire_script: empty when INPUT_CONCURRENCY_LOCK is false" {
+  INPUT_CONCURRENCY_LOCK="false"
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "build_lock_acquire_script: empty when INPUT_CONCURRENCY_LOCK is anything but 'true'" {
+  INPUT_CONCURRENCY_LOCK="TRUE"  # case-sensitive: only "true" enables
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ----------------------------------------------------------------------------
+# build_lock_acquire_script — enabled
+# ----------------------------------------------------------------------------
+
+@test "build_lock_acquire_script: emits a non-empty script when enabled with defaults" {
+  INPUT_CONCURRENCY_LOCK="true"
+  INPUT_CONCURRENCY_LOCK_PATH=".lftp-deployment.lock"
+  INPUT_CONCURRENCY_LOCK_TIMEOUT="300"
+  INPUT_CONCURRENCY_LOCK_POLL_INTERVAL="5"
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  # The acquire script must contain a repeat-based lock loop.
+  echo "$output" | grep -q "repeat --until-ok"
+  echo "$output" | grep -q "quote MKD .lftp-deployment.lock"
+  # count = ceil(300/5) = 60
+  echo "$output" | grep -q -- "-c 60"
+  echo "$output" | grep -q -- "-d 5"
+  # The script must end with `&& ` so the next lftp command (the
+  # mirror) only runs if the acquire succeeded.
+  echo "$output" | grep -qE '&& *$'
+}
+
+@test "build_lock_acquire_script: with timeout=0 produces count=1 (single try, no retry)" {
+  INPUT_CONCURRENCY_LOCK="true"
+  INPUT_CONCURRENCY_LOCK_PATH=".lock"
+  INPUT_CONCURRENCY_LOCK_TIMEOUT="0"
+  INPUT_CONCURRENCY_LOCK_POLL_INTERVAL="5"
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q -- "-c 1"
+}
+
+@test "build_lock_acquire_script: counts ceil(timeout/poll) correctly" {
+  INPUT_CONCURRENCY_LOCK="true"
+  INPUT_CONCURRENCY_LOCK_PATH=".lock"
+  INPUT_CONCURRENCY_LOCK_TIMEOUT="300"
+  INPUT_CONCURRENCY_LOCK_POLL_INTERVAL="7"
+  # ceil(300/7) = 43
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q -- "-c 43"
+  echo "$output" | grep -q -- "-d 7"
+}
+
+@test "build_lock_acquire_script: passes the lock path verbatim to quote MKD" {
+  INPUT_CONCURRENCY_LOCK="true"
+  INPUT_CONCURRENCY_LOCK_PATH="/var/locks/deploy.lock"
+  INPUT_CONCURRENCY_LOCK_TIMEOUT="60"
+  INPUT_CONCURRENCY_LOCK_POLL_INTERVAL="5"
+  run build_lock_acquire_script
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "quote MKD /var/locks/deploy.lock"
+}
+
+# ----------------------------------------------------------------------------
+# build_lock_release_script
+# ----------------------------------------------------------------------------
+
+@test "build_lock_release_script: empty when disabled" {
+  unset INPUT_CONCURRENCY_LOCK
+  run build_lock_release_script
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "build_lock_release_script: emits quote RMD when enabled" {
+  INPUT_CONCURRENCY_LOCK="true"
+  INPUT_CONCURRENCY_LOCK_PATH=".lftp-deployment.lock"
+  run build_lock_release_script
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  echo "$output" | grep -q "quote RMD .lftp-deployment.lock"
+  # Release is best-effort: the next lftp command (quit) must still
+  # run, which is what the trailing `; ` guarantees.
+  echo "$output" | grep -qE '; *$'
+}
+
+# ----------------------------------------------------------------------------
+# run_lftp_lock_release
+# ----------------------------------------------------------------------------
+
+@test "run_lftp_lock_release: no-op when lock path is empty" {
+  # We need a fake server URL and netrc file that the function
+  # would otherwise try to use. The no-op path is checked first
+  # by an explicit `if [ -z "${_rlr_lock_path}" ]`, so we can pass
+  # a non-existent netrc without harm.
+  run run_lftp_lock_release "ftp://nonexistent.invalid" \
+                            "/tmp/does-not-exist-netrc" \
+                            ""
+  [ "$status" -eq 0 ]
+}
+
+@test "run_lftp_lock_release: no-op when netrc file is missing" {
+  run run_lftp_lock_release "ftp://nonexistent.invalid" \
+                            "/tmp/does-not-exist-netrc" \
+                            ".lftp-deployment.lock"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #77

Two workflows (or two runs of the same workflow) deploying to the same FTP server at the same time can corrupt each other: `lftp mirror --reverse` lists both source and target directories, then races on writes. Concurrent uploads with `--delete` are especially dangerous — each run can see the other's freshly-uploaded files and delete them as "no longer in the source". Closes the risk from PROPOSAL §5 #6.

## Research finding

lftp 4.9.3 has NO built-in server-side `lock` command (verified against `src/commands.cc::static_cmd_table` and the man page). The only lock-related setting is `file:use-lock`, which applies to local files only. The original ROADMAP §7 plan referred to "lftp `lock`"; this PR uses MKD/RMD as the actual primitive.

MKD/RMD are RFC 959 basics, supported by every FTP server (vsftpd, proftpd, Pure-FTPd, sftp-via-FTP-gateways, etc.). `mkdir(2)` is atomic on virtually every UNIX-like filesystem, so the race window is microseconds.

## What this PR does

- Four new opt-in inputs (all default to v2.7.0 behavior, so this is bit-for-bit backward compatible):
  - `concurrency_lock: false` (opt-in switch)
  - `concurrency_lock_path: .lftp-deployment.lock`
  - `concurrency_lock_timeout: 300` (0 = fail fast)
  - `concurrency_lock_poll_interval: 5` (rejected when 0)
- `build_lock_acquire_script` / `build_lock_release_script` / `run_lftp_lock_release` in `lib.sh`. All read inputs via `_indirection` — no new `eval` site.
- `run_lftp_once` extended with two extra parameters; when the lock is disabled, both are empty strings, so the composed lftp `-e` script is bit-for-bit identical to v2.7.0.
- Lock release is layered: (1) inline `quote RMD <path>` in the lftp `-e` script before `quit;`; (2) fallback `run_lftp_lock_release` in the EXIT trap (so a signal-killed lftp still releases the lock using the .netrc that is also about to be removed); (3) documentation of the manual recovery path for the rare case of a stale lock.
- The new README section "Concurrency / deployment lock" also promotes the GitHub Actions `concurrency:` block as Option A (recommended for the common case of a single workflow) and documents when to use the action's lock instead (Option B).

## Tests

- 11 new bats unit tests in `tests/unit/lock.bats`: empty / non-empty branches, `timeout=0` short-circuit, `ceil(timeout/poll)` for 300/5=60 and 300/7=43, path verbatim pass-through, no-op paths of `run_lftp_lock_release`.
- 3 new smoke tests in `tests/smoke.sh`: default-off no-fragments, `..` rejected with exit 2, `poll_interval=0` rejected with exit 2.

Total test count: 118 unit + 33 smoke + 1 contract + 3 release-smoke = 155 tests, all green locally. Shellcheck clean.

## Version

v2.8.0 (minor, backward compatible).