### PR TITLE
docs(readme): document FTPS implicit vs. explicit modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- **README: document the difference between plain FTP, implicit
+  FTPS (`ftps://`, port 990, TLS from byte 0), and explicit
+  FTPS (`ftp://` + `AUTH TLS`, port 21)**, and how they interact
+  with the `ftp_ssl_allow` input. Closes PROPOSAL §5 #3 ("FTPS
+  implícito vs. explícito sin documentar"). The new "Plain FTP
+  vs FTPS" subsection in `Security and SSL` covers the four
+  scheme × `ftp_ssl_allow` combinations, recommends the right
+  `server` value for each hosting type, and explains the
+  `ftps:initial-prot` escape hatch.
+- **README: add two troubleshooting rows** covering the "wrong
+  scheme" foot-gun (`getpeername: Connection refused` on
+  `ftps://host:990` from a server that only speaks explicit
+  FTPS on 21) and the legacy "PROT command not understood"
+  fall-back (lftp drops the data connection on a non-PROT-P
+  server). Both rows link back to the new subsection.
+
 ## [2.8.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,51 @@ By default, `ftp_ssl_allow` is set to `true` to ensure your connection is encryp
 
 > **Note on direct-IP connections**: lftp cannot validate a hostname against an IP-address certificate, so `ssl_verify_certificate: true` requires both a valid certificate and a hostname (not a bare IP) in the `server` input.
 
+### Plain FTP vs FTPS, and the two FTPS modes
+
+The action supports both plain FTP and FTPS, and FTPS has two
+distinct flavours. The choice is driven by the URL scheme in the
+`server` input **and** the `ftp_ssl_allow` toggle. Picking the
+wrong combination is the most common cause of "the action worked
+yesterday on a different FTP" reports.
+
+| `server` scheme | `ftp_ssl_allow` | What you get | Default port |
+|---|---|---|---|
+| `ftp://host` | `true` (default) | **Explicit FTPS** ([RFC 4217](https://datatracker.ietf.org/doc/html/rfc4217)). Plain TCP connect, the server advertises `AUTH`, lftp upgrades the control channel with `AUTH TLS`, then `PROT P` for data. Password is sent inside TLS. This is the default and the most common deployment. | 21 |
+| `ftp://host` | `false` | **Plain FTP.** Password and file contents are sent in clear. Only use this on a trusted LAN. | 21 |
+| `ftps://host` | `true` (default) | **Implicit FTPS** ([RFC 1738](https://datatracker.ietf.org/doc/html/rfc1738)). TLS from the very first byte — the server's welcome banner is already inside TLS. Most legacy "FTPS" hosting providers (and many Windows-IIS setups) speak this. | 990 |
+| `ftps://host` | `false` | **Inconsistent** — lftp will still try to negotiate TLS because the URL scheme is `ftps://`. The action exits with a protocol error. The `ftp_ssl_allow` input is effectively ignored when the scheme is `ftps://`. | 990 |
+
+The two `ssl:verify-certificate` and `ssl:check-hostname` settings
+apply to every row above except the plain-FTP one (which has no
+TLS handshake to verify). For the `ftps://` rows, lftp also honours
+`ftps:initial-prot` (C, S, E, P, or empty) — leave it at the
+default `""` unless the server has a known PROT-bug workaround;
+the action does not set it.
+
+#### Picking the right `server` value
+
+- **Modern shared hoster with TLS** (most "free" or cheap web
+  hosts): `ftp://ftp.example.com` — the action's default gives
+  you explicit FTPS on port 21.
+- **Legacy FTPS host on port 990** (some cPanel / Plesk setups,
+  many IIS deployments, some European hosters): use
+  `ftps://ftp.example.com` or `ftps://ftp.example.com:990`.
+  Leave `ftp_ssl_allow` at its default.
+- **No TLS at all** (in-house FTP, an old NAS): use
+  `ftp://host` **and** set `ftp_ssl_allow: "false"`. You must
+  also set `ssl_verify_certificate: "false"` (it has no effect
+  on a plain FTP connection but the action's `validate_int` will
+  still require the value to be parseable).
+
+> **Troubleshooting hand-off**: if the runner reports
+> `getpeername: Connection refused` on `ftps://host:990`, the
+> server is most likely **not** an implicit-FTPS server (some
+> providers run explicit-only on 21, others run implicit on
+> 990). Switch the scheme to `ftp://` and the port to `21`,
+> keeping `ftp_ssl_allow: "true"`. See the
+> [Troubleshooting](#troubleshooting) table below.
+
 ## Usage Example
 
 Add this code in `./.github/workflows/your_action.yml`.
@@ -81,6 +126,15 @@ Usually the zero values mean unlimited or infinite. This table is based on the d
 | concurrency_lock_path  | Path of the sentinel directory used by `concurrency_lock`. Must be a valid FTP path (no `..`, no shell metacharacters, no leading dash). | No       | .lftp-deployment.lock | N/A                                                                                |
 | concurrency_lock_timeout | Maximum seconds to wait for the lock when `concurrency_lock` is "true" and another run is currently holding it. `0` means fail immediately when held. | No | 300  | N/A                                                                                               |
 | concurrency_lock_poll_interval | Seconds between lock acquisition attempts.                                                  | No       | 5       | N/A                                                                                               |
+
+> **How `ftp_ssl_allow` interacts with the `server` URL scheme.**
+> The default `ftp_ssl_allow: "true"` only takes effect when the
+> `server` input uses the `ftp://` scheme (explicit FTPS, port 21).
+> If you point the action at an implicit-FTPS server with
+> `ftps://host:990`, lftp speaks TLS regardless of `ftp_ssl_allow`,
+> and setting it to `"false"` actually breaks the connection. See
+> the "Plain FTP vs FTPS" table in [Security and SSL](#security-and-ssl)
+> for the full matrix.
 
 More information on the official site for [lftp - Manual pages][2].
 
@@ -450,6 +504,8 @@ log for debugging).
 | `Fatal error: certificate verify failed` (TLS) | The server uses a self-signed certificate, the cert is expired, or you are connecting to a bare IP. | `ssl_verify_certificate` is `true` by default since v2.0.0. If you trust the server, set `ssl_verify_certificate: "false"` explicitly. For a bare IP you cannot validate a hostname — use a hostname with a real cert or opt out. |
 | `Connection refused` / hangs on connect | Wrong host/port, firewall blocking outbound 21/990, or the FTP server is down. | Verify `server` (`ftp://host:21` or `ftps://host:990`). From the runner, `nc -vz host 21` should succeed. Some shared hosters block the runner's IP range — ask them to allow-list it. |
 | `mirror: Access failed: 550 ... No such file or directory` | The remote path does not exist or the FTP user has no permission to create it. | Create the `remote_dir` manually (or set `delete: false` and accept a partial mirror) and confirm the FTP user owns it. |
+| `getpeername: Connection refused` on `ftps://host:990` | The server is **not** speaking implicit FTPS — it is almost certainly explicit FTPS on port 21. The `ftps://` URL forces TLS from byte 0, which the server rejects. | Switch `server` to `ftp://host:21` and keep `ftp_ssl_allow: "true"`. See the "Plain FTP vs FTPS" table in [Security and SSL](#security-and-ssl). |
+| lftp logs `PROT command not understood` then drops the data connection | Some legacy FTPS servers do not support `PROT P` even though they accept `AUTH TLS`. lftp falls back to `PROT C` (clear data channel) by default; if the server closes the data connection instead, the action exits 1. | Add `lftp_settings: "set ftps:initial-prot C;"` to the step, or ask the hoster to enable `PROT P` server-side. |
 
 > **The job is still running for hours**: `lftp` is probably waiting on a
 > half-open TCP connection. Since v1.5.0 the action wraps every


### PR DESCRIPTION
Closes #79

## What

Docs-only change. Three additions to `README.md`, one to `CHANGELOG.md`. No code, no inputs, no behaviour change.

## Why

PROPOSAL.md §5 #3 (\"FTPS implícito vs. explícito sin documentar\") is the last open risk from the original 18-bug audit that is actionable in docs. Risks #1 (lftp 5.x — not in alpine 3.24 or edge) and #4 (`lftp_settings` cross-validation — explicitly deprioritised) are not actionable in this iteration. Risk #6 (concurrent deploys) was already closed in v2.8.0.

The `server` URL scheme and the `ftp_ssl_allow` toggle interact in a way that the README does not currently explain, and that interaction is the most common cause of \"the action worked yesterday on a different FTP\" support tickets.

## Changes

1. `README.md` §Security and SSL → new \"Plain FTP vs FTPS, and the two FTPS modes\" subsection with a 4-row scheme × `ftp_ssl_allow` matrix, RFC references (4217 explicit, 1738 implicit), and a \"Picking the right `server` value\" bullet list.
2. `README.md` §Settings → footnote pointing back to the new subsection and warning that `ftp_ssl_allow: \"false\"` breaks `ftps://` connections.
3. `README.md` §Troubleshooting → 2 new rows: \"Connection refused on ftps://host:990\" (wrong-scheme foot-gun) and \"PROT command not understood\" (legacy FTPS server fall-back).
4. `CHANGELOG.md` → new `[Unreleased]` → `Documentation` block.

## Verification

- `make shellcheck` — clean (no shell changes).
- `make contract` — 31/31 inputs match (no `action.yml` changes).
- `make unit` — 118/118 tests pass (no `lib.sh` changes).
- CI will run on the PR; expected to be all-green because no shell, action, container, or unit test files were touched.

## No version bump

This change is purely documentation. It will accumulate into the next tag (whatever that is — `v2.8.1` patch, `v2.9.0` minor with the stale-lock auto-recovery, or the next thing on the roadmap). The release pipeline is not triggered by a docs-only PR.