### PR TITLE
feat(ci): create draft GitHub Release in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   id-token: write
   attestations: write
@@ -138,3 +138,55 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           sbom-path: sbom.cyclonedx.json
           push-to-registry: true
+
+      # Extract the CHANGELOG.md section for this version so the
+      # GitHub Release body mirrors the existing markdown. The
+      # awk pattern ignores any `## [Unreleased]` block (defensive
+      # against the duplicate that lived in the changelog once and
+      # against future [Unreleased] entries) and stops at the next
+      # `## [...]` heading or the compare-link footer for this
+      # version. `body-empty=true` is exported when no section was
+      # found, so the next step can fall back to
+      # `generate_release_notes: true`.
+      - name: Extract CHANGELOG notes for this version
+        id: notes
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          notes=$(awk -v v="${version}" '
+              BEGIN {
+                  in_section = 0
+                  v_escaped = v
+                  gsub(/\./, "\\.", v_escaped)
+                  heading_re = "^## \\[" v_escaped "\\]( -.*)?$"
+                  next_heading_re = "^## \\["
+                  compare_re = "^\\[[0-9]+\\.[0-9]+\\.[0-9]+\\]:"
+              }
+              $0 ~ heading_re { in_section = 1; next }
+              in_section && $0 ~ next_heading_re { exit }
+              in_section && $0 ~ compare_re { exit }
+              in_section { print }
+          ' CHANGELOG.md)
+          if [ -z "${notes}" ]; then
+            echo "::warning::no CHANGELOG section found for ${version}; falling back to generate_release_notes"
+            echo "body-empty=true" >> "$GITHUB_OUTPUT"
+          else
+            body_file=$(mktemp)
+            printf '%s\n' "${notes}" > "${body_file}"
+            echo "body-file=${body_file}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Create a draft GitHub Release so a human can review and
+      # publish it after the image is already on ghcr.io. Drafts
+      # are intentional (not auto-publish): the maintainer reads
+      # the rendered body and the asset list before going public.
+      # If the previous step did not find a CHANGELOG section,
+      # `generate_release_notes: true` lets GitHub build the body
+      # from the tag delta instead.
+      - name: Create draft GitHub Release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          draft: true
+          generate_release_notes: ${{ steps.notes.outputs.body-empty == 'true' }}
+          body_path: ${{ steps.notes.outputs.body-file }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,66 +330,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.5.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.4.1...v2.5.0
 
 
-## [Unreleased]
-
-### Added
-
-- **bats unit tests for `lib.sh`** (5 files, 92 tests in
-  `tests/unit/`). Each pure function in the library now has at
-  least one happy-path and one reject-path test that runs in
-  under 2 minutes without spinning up docker, alpine, or lftp.
-  CI gets a new `unit` job that installs bats via `apt-get` and
-  runs `bats tests/unit`. A `make unit` target is added for
-  local iteration; it skips with a notice if bats is not
-  installed.
-
-### Changed
-
-- **Architectural refactor (LP-1 / MP-5)**: split the previously
-  monolithic `init.sh` (657 lines) into an orchestrator
-  (`entrypoint.sh`, ~190 lines) and a library of pure functions
-  (`lib.sh`, ~620 lines). The entrypoint sources the library and
-  drives the workflow; the library contains every validation,
-  parser, builder, retry helper, and reporting function. **Zero
-  behaviour change** vs. v2.4.1 — the action still accepts the
-  same inputs, produces the same exit codes, and the smoke tests
-  pass unmodified apart from the path to the entrypoint.
-- Deduplicate the 12 near-identical `if/else` branches that built
-  `FTP_SETTINGS` into a single positional-parameter-driven loop in
-  `build_ftp_settings` (lib.sh). Same keys, same defaults, same
-  order.
-- Replace the `eval "_cur=\${INPUT_${_v}-}"` indirection in the
-  inputs dump with an explicit list of variable names plus a
-  single `_indirection` helper in `lib.sh`. Dynamic variable-name
-  lookup now happens in exactly one place in the entire codebase.
-- `extract_netrc_host` now correctly handles the IPv6 form
-  `[::1]:990` (bracketed host with a port suffix) in addition to
-  `[::1]` (no port). The previous `\[*\])` glob required the
-  value to end with `]`, which silently failed on
-  `ftps://[::1]:990` and produced an empty string instead of
-  `::1`. Caught by the new `extract_netrc_host: ftps://[::1]:990
-  -> ::1` unit test.
-- The contract test (`tests/contract.sh`) now greps both
-  `entrypoint.sh` and `lib.sh` for `INPUT_*` references; the
-  static and dynamic sets must still match the declared inputs in
-  `action.yml`.
-
-### Internal
-
-- `Dockerfile`: `COPY entrypoint.sh lib.sh /app/`, `ENTRYPOINT
-  ["/app/entrypoint.sh"]`.
-- `Makefile`: `shellcheck -x entrypoint.sh lib.sh tests/contract.sh
-  tests/smoke.sh`. The `-x` flag is required so shellcheck follows
-  the `shellcheck source=lib.sh` directive in `entrypoint.sh`.
-- `Makefile`: `make unit` target for the bats tests.
-- `tests/smoke.sh`: `INIT_REL=./entrypoint.sh` (1-line path change
-  in the harness; the test bodies are unchanged).
-- `.github/workflows/ci.yml`: new `unit` job that installs bats
-  and runs `bats tests/unit`; existing `shellcheck` job now
-  covers `entrypoint.sh + lib.sh` and the `contract` job's name
-  reflects the new contract test path.
-
-
 ## [2.4.1] - 2026-07-05
 
 Hotfix. The v2.4.0 release was cut but its job setup failed:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ shellcheck:
 		echo "shellcheck not found; install with: apt-get install shellcheck / apk add shellcheck"; \
 		exit 1; }
 	# -x: follow `shellcheck source=` directives (entrypoint.sh sources lib.sh).
-	shellcheck -x entrypoint.sh lib.sh tests/contract.sh tests/smoke.sh
+	shellcheck -x entrypoint.sh lib.sh tests/contract.sh tests/smoke.sh scripts/backfill-releases.sh
 
 .PHONY: actionlint
 actionlint:

--- a/scripts/backfill-releases.sh
+++ b/scripts/backfill-releases.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# scripts/backfill-releases.sh — Backfill missing GitHub Releases
+# for tags that were tagged locally but never published as a
+# GitHub Release on github.com. The release pipeline
+# (.github/workflows/release.yml) builds and signs images for
+# ghcr.io, but historically did not create the corresponding
+# GitHub Release page. This script makes those pages retroactive
+# as drafts so a human can review and publish them.
+#
+# Usage:
+#   scripts/backfill-releases.sh [--dry-run]
+#
+# Idempotent: skips tags that already have a release on github.com.
+# Exits non-zero if any create failed.
+#
+# Notes are extracted from CHANGELOG.md by matching the
+# `## [X.Y.Z]` heading and capturing until the next `## [...]`
+# heading or the compare-link footer. The script ignores
+# `## [Unreleased]` blocks (which would otherwise be confused
+# with version sections).
+#
+# Requires:
+#   - gh CLI authenticated (gh auth status).
+#   - awk, sed, mktemp (POSIX).
+
+set -eu
+
+DRY_RUN=0
+case "${1:-}" in
+    --dry-run) DRY_RUN=1 ;;
+    "") ;;
+    *) echo "usage: $0 [--dry-run]" >&2; exit 64 ;;
+esac
+
+cd "$(dirname "$0")/.."
+ROOT=$(pwd)
+CHANGELOG="${ROOT}/CHANGELOG.md"
+
+if [ ! -f "${CHANGELOG}" ]; then
+    echo "missing ${CHANGELOG}" >&2
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI not found on PATH" >&2
+    exit 1
+fi
+
+if [ "${DRY_RUN}" -ne 1 ]; then
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "gh is not authenticated; run 'gh auth login' first" >&2
+        exit 1
+    fi
+fi
+
+TAGS="v2.1.0 v2.2.0 v2.3.0 v2.3.1 v2.4.0 v2.4.1 v2.5.0 v2.6.0 v2.7.0 v2.8.0"
+
+extract_section() {
+    _v="$1"
+    awk -v v="${_v}" '
+        BEGIN {
+            in_section = 0
+            v_escaped = v
+            gsub(/\./, "\\.", v_escaped)
+            heading_re = "^## \\[" v_escaped "\\]( -.*)?$"
+            next_heading_re = "^## \\["
+            compare_re = "^\\[[0-9]+\\.[0-9]+\\.[0-9]+\\]:"
+        }
+        $0 ~ heading_re { in_section = 1; next }
+        in_section && $0 ~ next_heading_re { exit }
+        in_section && $0 ~ compare_re { exit }
+        in_section { print }
+    ' "${CHANGELOG}" | awk '
+        # Collapse runs of blank lines to a single blank line,
+        # and trim any trailing blank lines. Both produce a
+        # tidy block for a GitHub release body without ever
+        # turning awk into an infinite loop on an empty input.
+        BEGIN { seen_blank = 0 }
+        NF {
+            print
+            seen_blank = 0
+        }
+        !NF {
+            if (seen_blank) next
+            print
+            seen_blank = 1
+        }
+        END {
+            # Drop the single trailing blank if any.
+            exit seen_blank ? 0 : 0
+        }
+    ' | awk '
+        # Strip a single trailing blank line emitted above.
+        { lines[NR] = $0 }
+        END {
+            last = NR
+            while (last > 0 && lines[last] == "") last--
+            for (i = 1; i <= last; i++) print lines[i]
+        }
+    '
+}
+
+N_CREATED=0
+N_SKIPPED=0
+N_FAILED=0
+N_GENERATED=0
+
+for tag in ${TAGS}; do
+    if gh release view "${tag}" >/dev/null 2>&1; then
+        printf 'skip:    %s (release already exists on github.com)\n' "${tag}"
+        N_SKIPPED=$((N_SKIPPED + 1))
+        continue
+    fi
+
+    version="${tag#v}"
+
+    # Resolve the commit SHA the tag points at. `gh release
+    # create --target <tag-name>` is rejected by the GitHub
+    # API with a 422 ("Release.target_commitish is invalid");
+    # the API wants either a branch name or a full SHA. The
+    # SHA lets us anchor the release at the tag's actual commit
+    # rather than at the tip of `main`, which is what we want.
+    # During draft state GitHub shows a placeholder URL like
+    # `untagged-<id>`; once published the URL becomes
+    # `releases/tag/<tag>`.
+    tag_sha=$(git rev-parse "${tag}^{}" 2>/dev/null || git rev-parse "${tag}")
+    if [ -z "${tag_sha}" ]; then
+        printf 'FAIL:    %s — could not resolve commit SHA\n' "${tag}" >&2
+        N_FAILED=$((N_FAILED + 1))
+        continue
+    fi
+
+    notes=$(extract_section "${version}")
+    notes_file=""
+
+    if [ -z "${notes}" ]; then
+        printf 'warn:    %s — no CHANGELOG section found for %s; will use --generate-notes\n' "${tag}" "${version}"
+        notes_flag="generate"
+    else
+        notes_file=$(mktemp) || exit 1
+        printf '%s\n' "${notes}" > "${notes_file}"
+        notes_flag="file"
+    fi
+
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        if [ "${notes_flag}" = "file" ]; then
+            printf 'would:    create draft for %s (target=%s, notes %d bytes from CHANGELOG)\n' "${tag}" "${tag_sha}" "$(wc -c < "${notes_file}")"
+            rm -f "${notes_file}"
+        else
+            printf 'would:    create draft for %s (target=%s, with --generate-notes)\n' "${tag}" "${tag_sha}"
+        fi
+        continue
+    fi
+
+    if [ "${notes_flag}" = "file" ]; then
+        if gh release create "${tag}" \
+                --draft \
+                --target "${tag_sha}" \
+                --title "${tag}" \
+                --notes-file "${notes_file}"; then
+            printf 'created: %s (draft, notes from CHANGELOG)\n' "${tag}"
+            N_CREATED=$((N_CREATED + 1))
+        else
+            printf 'FAIL:    %s\n' "${tag}" >&2
+            N_FAILED=$((N_FAILED + 1))
+        fi
+        rm -f "${notes_file}"
+    else
+        if gh release create "${tag}" \
+                --draft \
+                --target "${tag_sha}" \
+                --title "${tag}" \
+                --generate-notes; then
+            printf 'created: %s (draft, auto-generated notes)\n' "${tag}"
+            N_GENERATED=$((N_GENERATED + 1))
+        else
+            printf 'FAIL:    %s\n' "${tag}" >&2
+            N_FAILED=$((N_FAILED + 1))
+        fi
+    fi
+done
+
+printf '\nsummary: created=%d (changelog) + %d (auto-notes), skipped=%d, failed=%d\n' \
+    "${N_CREATED}" "${N_GENERATED}" "${N_SKIPPED}" "${N_FAILED}"
+
+[ "${N_FAILED}" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #81.

## What

The release pipeline builds, signs, and SBOM-attests the
container image on every pushed tag, but never created the
matching GitHub Release page on github.com. v2.1.0 .. v2.8.0
were tagged and pushed to ghcr.io, but have no human-facing
release. This PR closes that gap:

1. **release.yml — `contents: write`** plus a final step that
   creates a **draft** GitHub Release via
   `softprops/action-gh-release@v3.0.1` (SHA-pinned, like every
   other action in this workflow). The body comes from the
   matching `## [X.Y.Z]` section of `CHANGELOG.md`, extracted
   by an `awk` one-liner that ignores `## [Unreleased]` blocks
   and stops at the next heading or compare-link footer. If no
   section is found, the step exports `body-empty=true` and the
   next step enables `generate_release_notes` as a fallback.
   `draft: true` is intentional: the maintainer reads the
   rendered body and asset list before clicking *Publish*.

2. **`scripts/backfill-releases.sh` (new)** — an idempotent
   shell script that creates the missing GitHub Releases for
   the ten pre-existing tags (v2.1.0 .. v2.8.0) as drafts, using
   `git rev-parse <tag>^{}` for the commit SHA (the GitHub API
   rejects a tag name as `target_commitish` with a 422, so we
   resolve the SHA locally). Supports `--dry-run`; skips tags
   that already have a release. **Already executed locally**:
   ten drafts now sit at `github.com/airvzxf/ftp-deployment-action/releases`
   with title `vX.Y.Z` and the matching CHANGELOG section.

## Why a draft, not auto-publish

A draft keeps a human in the loop on what is *user-facing*.
Auto-publish means the body and asset list go live the moment
the image lands on ghcr.io, with no chance to catch a typo or
a stale section. The cost is one click per release, in
exchange for never accidentally publishing a release with a
broken body or missing assets. The contributor of the new tag
can also publish before announcing it on social, etc.

## Plus

- **`CHANGELOG.md`** had a duplicate `## [Unreleased]` block
  that was a literal copy of the v2.5.0 notes (left between the
  v2.5.0 and v2.4.1 sections). The awk extractor handled it,
  but I deleted it because the file is supposed to be readable
  top-to-bottom. The leg of the diff is a `-60` change.

- **`Makefile`** now passes the new script to `shellcheck -x`.

## Verification

| Check | Result |
|---|---|
| `make shellcheck` | clean (4 scripts + `scripts/backfill-releases.sh`) |
| `make contract` | 31/31 inputs match |
| `make unit` | 118/118 bats tests green |
| `scripts/backfill-releases.sh` (already run locally) | 10 drafts on github.com |
| `scripts/backfill-releases.sh --dry-run` (now idempotent) | 10/10 *skip* (existing) |
| actionlint (v1.7.12, downloaded ad hoc) | clean for `.github/workflows/release.yml` |
| yaml parse | OK |

## Files changed

- `.github/workflows/release.yml` — 52 added (CHANGELOG extract step + draft-release step + permission bump)
- `CHANGELOG.md` — 60 removed (duplicate `## [Unreleased]` block)
- `Makefile` — 1 changed (add `scripts/backfill-releases.sh` to shellcheck list)
- `scripts/backfill-releases.sh` — new, +169 lines

## How to verify the pipeline after merge

The next tag push (`v2.9.0` when the stale-lock auto-recovery
work lands, or any hotfix) should:
1. Build and push the image (existing behaviour).
2. Generate SBOM, sign with cosign, attach attestation (existing).
3. Create a new draft at `releases/tag/v<X>.<Y>.<Z>` with body
   equal to the matching CHANGELOG section (new).

To inspect: `gh release view v<X>.<Y>.<Z>` immediately after
the workflow run completes — the URL will be `untagged-…`
while the release is a draft, and flips to
`releases/tag/v<X>.<Y>.<Z>` after publishing.