### PR TITLE
fix(ci): publish GitHub Release automatically on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,18 +175,23 @@ jobs:
             echo "body-file=${body_file}" >> "$GITHUB_OUTPUT"
           fi
 
-      # Create a draft GitHub Release so a human can review and
-      # publish it after the image is already on ghcr.io. Drafts
-      # are intentional (not auto-publish): the maintainer reads
-      # the rendered body and the asset list before going public.
+      # Create a GitHub Release for the tag. Auto-publish: a tag
+      # in this repo is the maintainer's already-made decision to
+      # ship, so the release goes live the moment the image is
+      # signed and attached (no manual click). If a release turns
+      # out to be wrong, the recovery path is a hotfix tag +
+      # `gh release edit <bad-tag> --prerelease` (or delete via
+      # the API), not a draft kept in reserve. `make_latest: 'true'`
+      # marks this release as Latest so notification feeds and
+      # tooling that hits `/releases/latest` see the new tag.
       # If the previous step did not find a CHANGELOG section,
-      # `generate_release_notes: true` lets GitHub build the body
-      # from the tag delta instead.
-      - name: Create draft GitHub Release
+      # `generate_release_notes` builds the body from the tag
+      # delta as a fallback.
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}
-          draft: true
+          make_latest: 'true'
           generate_release_notes: ${{ steps.notes.outputs.body-empty == 'true' }}
           body_path: ${{ steps.notes.outputs.body-file }}


### PR DESCRIPTION
Closes #83.

## What

PR #82 (#81) created the GitHub Release for every tag as a
*draft* so the maintainer could read the body and asset list
before clicking Publish. In practice the workflow already
gates on signed image, smoke test, SBOM, cosign signature,
and SBOM attestation — every one of which fails loudly if
anything is wrong. A draft added a manual publish step that
bought very little safety (the same maintainer just signed
the tag) at the cost of confusing `untagged-…` URLs, the
Latest release pointing at v2.0.1 even after v2.8.0 landed,
and notification feeds never firing for v2.1.0+.

This PR replaces `draft: true` with `make_latest: 'true'`.
Future tag pushes will produce a **published** release with
the matching CHANGELOG section as its body, marked as Latest.

## Why this is the right default

A tag in this repo is the maintainer's already-made decision
to ship. The recovery path for a bad release stays the same
as it was before any of this PR existed:

- Cut a hotfix tag (`v2.8.1`, `v2.9.0`, …).
- If the bad release must be hidden right now, `gh release
  edit <bad-tag> --prerelease` or delete via the API. There
  is no draft kept in reserve.

## What stays the same

- The ten backfilled drafts for v2.1.0 … v2.8.0 (created by
  PR #82's `scripts/backfill-releases.sh` run) are unaffected.
  They remain as drafts for the maintainer to publish when
  ready.
- The body extraction (`Extract CHANGELOG notes for this
  version`) and the `body-empty=true` fallback to
  `generate_release_notes` are unchanged.
- The action SHA pinning (`softprops/action-gh-release@
  718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1`) and
  `contents: write` permission are unchanged.

## Files changed

- `.github/workflows/release.yml` — 13 added, 8 removed
  (`draft: true` → `make_latest: 'true'`, plus updated
  comment).

## Verification

| Check | Result |
|---|---|
| yaml parse | OK |
| actionlint (v1.7.12) | clean for `release.yml` |
| `make shellcheck` | unchanged (no shell files touched) |
| Commit signature | GPG `G` (`git log %G?`) |

## How to verify the new behavior after merge

Push any new `v*.*.*` tag (e.g. `git tag v2.8.1-test.0`
locally and `git push origin v2.8.1-test.0` from a feature
branch — or wait for the next legitimate hotfix). The
release pipeline will run, and the GitHub Release will be
visible at `releases/tag/<tag>` immediately, marked as
Latest. `gh release view <tag>` will show `isDraft: false`.