### PR TITLE
feat(release): publish to Docker Hub and ECR Public (LP-7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
         required: true
         type: string
 
+# `id-token: write` is required for two OIDC flows: cosign keyless
+# signing (Sigstore Fulcio) and AWS role assumption
+# (aws-actions/configure-aws-credentials@v4 with role-to-assume).
 permissions:
   contents: write
   packages: write
@@ -26,10 +29,31 @@ jobs:
   release:
     name: Build, sign and publish
     runs-on: ubuntu-latest
+    # The pipeline tolerates the absence of DOCKERHUB_* and
+    # AWS_ROLE_TO_ASSUME secrets: in that case the corresponding
+    # registry is skipped (a ::notice:: is emitted). ghcr.io is
+    # always published because GITHUB_TOKEN is automatic. Set
+    # both Docker Hub PAT secrets and AWS_ROLE_TO_ASSUME on the
+    # repo to publish to all three registries on every release.
+    # See README section "Publishing targets" for the one-time
+    # setup.
     steps:
-      - name: Resolve tag and version
+      # v2.10.0+: this step resolves the tag/version (unchanged
+      # from v2.9.0) AND decides which secondary registries are
+      # enabled, based on the presence of
+      # DOCKERHUB_USERNAME+DOCKERHUB_TOKEN and AWS_ROLE_TO_ASSUME
+      # secrets. The `all_tags` output is a heredoc YAML literal
+      # the build-push step consumes verbatim; conditional
+      # registries contribute zero lines because we only append
+      # when their flag is on.
+      - name: Resolve tag, version and enabled registries
         id: meta
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         run: |
+          set -eu
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             tag="${{ inputs.version }}"
           else
@@ -37,12 +61,52 @@ jobs:
           fi
           version="${tag#v}"
           image="ghcr.io/${{ github.repository_owner }}/ftp-deployment-action"
+
           {
             echo "tag=${tag}"
             echo "version=${version}"
             echo "image=${image}"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved tag=${tag}, version=${version}, image=${image}"
+
+          # ghcr.io is always published (GITHUB_TOKEN is automatic).
+          tags="${image}:${version}"$'\n'"${image}:${tag}"$'\n'"${image}:latest"
+
+          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            dockerhub_image="docker.io/airvzxf/ftp-deployment-action"
+            tags="${tags}"$'\n'"${dockerhub_image}:${version}"$'\n'"${dockerhub_image}:${tag}"$'\n'"${dockerhub_image}:latest"
+            {
+              echo "dockerhub_image=${dockerhub_image}"
+              echo "dockerhub_enabled=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "Docker Hub publishing ENABLED (${dockerhub_image})"
+          else
+            echo "::notice::Docker Hub secrets (DOCKERHUB_USERNAME, DOCKERHUB_TOKEN) not set; skipping docker.io publish"
+          fi
+
+          if [ -n "${AWS_ROLE_TO_ASSUME}" ]; then
+            ecr_image="public.ecr.aws/airvzxf/ftp-deployment-action"
+            tags="${tags}"$'\n'"${ecr_image}:${version}"$'\n'"${ecr_image}:${tag}"$'\n'"${ecr_image}:latest"
+            {
+              echo "ecr_image=${ecr_image}"
+              echo "ecr_enabled=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "ECR Public publishing ENABLED (${ecr_image})"
+          else
+            echo "::notice::AWS_ROLE_TO_ASSUME secret not set; skipping public.ecr.aws publish"
+          fi
+
+          # Heredoc-style multi-line output for `all_tags`. The
+          # build-push step consumes it as a YAML block scalar;
+          # the trailing newline is stripped by the consumer.
+          {
+            echo "all_tags<<EOF"
+            printf '%s' "${tags}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved tag=${tag}, version=${version}"
+          echo "Tags to push:"
+          printf '%s\n' "${tags}"
 
       - name: Checkout source at the release tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,6 +124,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # v2.10.0+: Docker Hub is a SECONDARY publish target. The
+      # conditional is gated on both DOCKERHUB_USERNAME and
+      # DOCKERHUB_TOKEN being present; missing either is a no-op
+      # (with a ::notice:: from the meta step) so forks and the
+      # upstream maintainer can iterate without touching secrets
+      # globally.
+      - name: Log in to Docker Hub
+        if: ${{ steps.meta.outputs.dockerhub_enabled == 'true' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # v2.10.0+: ECR Public is a SECONDARY publish target. OIDC
+      # role assumption (no static AWS secrets) is configured in
+      # two steps: configure-aws-credentials assumes the role and
+      # exports AWS_ACCESS_KEY_ID/secret/session to subsequent
+      # steps; amazon-ecr-login then uses those credentials to
+      # call ecr-public:GetAuthorizationToken and to docker login
+      # to public.ecr.aws. The IAM role trust policy must list
+      # `token.actions.githubusercontent.com` as a federated
+      # principal with a `sub` condition matching this repo (see
+      # README section "Publishing targets" for the JSON).
+      - name: Configure AWS credentials (OIDC) for ECR Public
+        if: ${{ steps.meta.outputs.ecr_enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          # ECR Public control plane lives in us-east-1 regardless
+          # of where the ECR Public registry "lives" (ECR Public
+          # has no region concept; the public.ecr.aws endpoint is
+          # global).
+          aws-region: us-east-1
+
+      - name: Log in to ECR Public
+        if: ${{ steps.meta.outputs.ecr_enabled == 'true' }}
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build and push image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -71,10 +176,12 @@ jobs:
           # deprecation warning can print the actual image version
           # (default in the Dockerfile is "dev" for local builds).
           build-args: VERSION=${{ steps.meta.outputs.tag }}
-          tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
-            ${{ steps.meta.outputs.image }}:latest
+          # `all_tags` is a multi-line string emitted by the meta
+          # step. The buildx builder receives every tag exactly
+          # once and pushes each to the corresponding registry
+          # (docker/build-push-action routes per-tag based on the
+          # registry hostname).
+          tags: ${{ steps.meta.outputs.all_tags }}
           labels: |
             org.opencontainers.image.title=ftp-deployment-action
             org.opencontainers.image.description=GitHub Action that copies files via FTP/FTPS using lftp
@@ -87,7 +194,7 @@ jobs:
       # v2.4.0+: smoke-test the just-pushed image before signing
       # and attaching the SBOM. The release pipeline previously
       # only exercised the image via CI (which runs init.sh
-      # against a plain alpine:3.23.3 — not the published image
+      # against a plain alpine:3.23.3, not the published image
       # with its pinned lftp and ca-certificates versions). The
       # v2.3.0 release was cut and pushed with a build that
       # could not resolve lftp=4.9.2-r9 against the new alpine
@@ -98,9 +205,16 @@ jobs:
       # pulls the just-pushed image, runs three cheap checks
       # (path-traversal validation, deprecation warning, the
       # /app/VERSION bake), and aborts the pipeline on any
-      # failure. SBOM generation, cosign signing, and the
-      # SBOM attestation are skipped on failure, so we never
-      # publish or sign a broken image.
+      # failure. SBOM generation, cosign signing, and the SBOM
+      # attestation are skipped on failure, so we never publish
+      # or sign a broken image.
+      #
+      # v2.10.0+: smoke-test only the ghcr.io image. The three
+      # registries receive the exact same image bytes from a
+      # single `docker buildx build`, so a ghcr.io failure
+      # implies the same failure on docker.io and public.ecr.aws.
+      # Pulling the image three times would triple the pipeline
+      # latency for zero added coverage.
       - name: Smoke test the just-pushed image
         env:
           IMAGE: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
@@ -124,17 +238,53 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      # v2.10.0+: sign every published image. The digest is the
+      # same across registries (single build produces one OCI
+      # manifest, identical digests), so we sign
+      # `<registry>/<ns>/image@digest` per enabled registry. The
+      # digest is captured into an env var so secret masking
+      # doesn't apply.
       - name: Sign image with cosign (keyless, OIDC)
         env:
           COSIGN_EXPERIMENTAL: '1'
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes \
-            ${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}
+          set -eu
+          cosign sign --yes "${{ steps.meta.outputs.image }}@${DIGEST}"
+          if [ "${{ steps.meta.outputs.dockerhub_enabled }}" = "true" ]; then
+            cosign sign --yes "${{ steps.meta.outputs.dockerhub_image }}@${DIGEST}"
+          fi
+          if [ "${{ steps.meta.outputs.ecr_enabled }}" = "true" ]; then
+            cosign sign --yes "${{ steps.meta.outputs.ecr_image }}@${DIGEST}"
+          fi
 
-      - name: Attach SBOM attestation to the image
+      # v2.10.0+: attach the SBOM attestation to every published
+      # image. `actions/attest` takes a single (subject-name,
+      # subject-digest) pair per call, so we invoke it once per
+      # enabled registry. The signature, attestation, and image
+      # manifest together constitute the supply-chain bundle.
+      - name: Attach SBOM attestation to ghcr.io image
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ steps.meta.outputs.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.cyclonedx.json
+          push-to-registry: true
+
+      - name: Attach SBOM attestation to Docker Hub image
+        if: ${{ steps.meta.outputs.dockerhub_enabled == 'true' }}
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-name: ${{ steps.meta.outputs.dockerhub_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.cyclonedx.json
+          push-to-registry: true
+
+      - name: Attach SBOM attestation to ECR Public image
+        if: ${{ steps.meta.outputs.ecr_enabled == 'true' }}
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-name: ${{ steps.meta.outputs.ecr_image }}
           subject-digest: ${{ steps.build.outputs.digest }}
           sbom-path: sbom.cyclonedx.json
           push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-registry publishing for releases (LP-7)**. Every tag is
+  now pushed to **three** OCI registries (when the corresponding
+  secrets are present on the repo):
+
+  | Registry | Image | How to consume |
+  |---|---|---|
+  | ghcr.io (always) | `ghcr.io/airvzxf/ftp-deployment-action:<tag>` | `uses: airvzxf/ftp-deployment-action@v2` |
+  | Docker Hub (opt-in) | `docker.io/airvzxf/ftp-deployment-action:<tag>` | `uses: docker://docker.io/airvzxf/ftp-deployment-action@v2` |
+  | AWS ECR Public (opt-in, OIDC) | `public.ecr.aws/airvzxf/ftp-deployment-action:<tag>` | `uses: docker://public.ecr.aws/airvzxf/ftp-deployment-action@v2` |
+
+  The three registries receive the **same image bytes** from a
+  single `docker buildx build` (identical OCI manifest digest),
+  the **same** `cosign` keyless signature, and the **same**
+  CycloneDX SBOM attestation attached via `actions/attest`.
+  Docker Hub and ECR Public are **conditional on secrets
+  presence** — if `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` or
+  `AWS_ROLE_TO_ASSUME` are unset on the repo, the pipeline emits
+  a `::notice::` and skips that registry, preserving the v2.9.0
+  behaviour (ghcr.io only) bit-for-bit. The one-time setup for
+  Docker Hub (PAT) and ECR Public (OIDC IAM role + trust
+  policy) is documented in README §"Publishing targets".
+
+  *AWS auth uses OIDC role assumption* (no static AWS access
+  keys are stored in the repo): `aws-actions/configure-aws-credentials@v4`
+  assumes the role from `AWS_ROLE_TO_ASSUME`, and
+  `aws-actions/amazon-ecr-login@v2` performs the docker login
+  to `public.ecr.aws` using the resulting session credentials.
+  The IAM trust policy is pinned to `sub: repo:airvzxf/ftp-deployment-action:ref:refs/tags/v*`
+  so only signed-tag pushes from this repo can assume it.
+
+  The release pipeline (`release.yml`) changes are concentrated
+  in two steps: the `meta` step now resolves `all_tags`,
+  `dockerhub_enabled`, and `ecr_enabled` outputs based on secret
+  presence, and `cosign sign` + `actions/attest` are now invoked
+  once per enabled registry (ghcr.io is unconditional). The
+  smoke test deliberately pulls from ghcr.io only — the three
+  registries share one OCI manifest, so a ghcr.io failure
+  implies the same failure on docker.io and public.ecr.aws.
+
+### Documentation
+
+- **README §"Publishing targets"** — new section listing the
+  three registries, example `uses:` lines for each, and the
+  one-time maintainer setup for Docker Hub (PAT + 2 secrets)
+  and ECR Public (OIDC IAM role with a copy-pasteable trust
+  policy JSON and the minimum ECR Public permission set).
+- **README troubleshooting note** — a single new sentence
+  pointing users who explicitly want to consume from Docker Hub
+  or ECR Public at the `docker://` prefix pattern.
+
+
+## [2.9.0] - 2026-07-08
+
+### Added
+
 - **Stale-lock auto-recovery for `concurrency_lock`** (closes the
   residual risk from v2.8.0 documented in the CHANGELOG entry for
   v2.8.0 and the `concurrency_lock` input description: "if the
@@ -587,6 +642,7 @@ Four PRs on top of v2.1.0. No breaking change.
 [2.1.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.0.1...v2.1.0
 [2.0.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.5.0
+[2.9.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.8.0...v2.9.0
 [1.3.3]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.3.3
 
 ## [2.1.0] - 2026-07-05
@@ -792,5 +848,6 @@ Historical. See git history for changes prior to `CHANGELOG.md` adoption.
 [2.1.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.0.1...v2.1.0
 [2.0.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.5.0
+[2.9.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.8.0...v2.9.0
 [2.4.1]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.4.0...v2.4.1
 [1.3.3]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.3.3

--- a/README.md
+++ b/README.md
@@ -89,6 +89,126 @@ jobs:
 > tag (`@v2.0.0`) or a full commit SHA. Avoid `@latest` and `@main` —
 > they move under you and can introduce regressions.
 
+## Publishing targets (v2.10.0+)
+
+Every tag is published to **three registries** so consumers can
+pick whichever is closest (or already trusted) in their supply chain:
+
+| Registry | Image | How to consume |
+|---|---|---|
+| GitHub Container Registry (default) | `ghcr.io/airvzxf/ftp-deployment-action:v2.10.0` | `uses: airvzxf/ftp-deployment-action@v2` (the example above) |
+| Docker Hub | `docker.io/airvzxf/ftp-deployment-action:v2.10.0` | `uses: docker://docker.io/airvzxf/ftp-deployment-action@v2` |
+| AWS ECR Public | `public.ecr.aws/airvzxf/ftp-deployment-action:v2.10.0` | `uses: docker://public.ecr.aws/airvzxf/ftp-deployment-action@v2` |
+
+All three carry the same OCI image bytes (one `docker buildx build`,
+one digest), the same `cosign` keyless signature
+(`cosign verify --certificate-identity-regexp ... --certificate-oidc-issuer ...`
+against any of the three image refs), and the same CycloneDX SBOM
+attestation (attached via `actions/attest`). ghcr.io is always
+published; Docker Hub and ECR Public are **conditional on the
+repo having the right secrets configured** (see the
+[Maintainer setup](#maintainer-setup-publishing-to-docker-hub-and-ecr-public)
+section below). If a secret is missing, the release pipeline
+emits a `::notice::` and skips that registry — the v2.9.0
+behaviour (ghcr.io only) is preserved bit-for-bit.
+
+### Maintainer setup: publishing to Docker Hub and ECR Public
+
+These are **one-time** per-registry setups. They are not required
+to use the action; they are only required if you are the
+maintainer pushing new releases.
+
+**Docker Hub** (publishes to `docker.io/airvzxf/ftp-deployment-action`):
+
+1. Create a Docker Hub Personal Access Token (PAT) at
+   <https://hub.docker.com/settings/security> (read + write +
+   delete is fine; we only push).
+2. Add two repository secrets on
+   <https://github.com/airvzxf/ftp-deployment-action/settings/secrets/actions>:
+   * `DOCKERHUB_USERNAME` — your Docker Hub username (the namespace
+     owner; for this repo, that is `airvzxf`).
+   * `DOCKERHUB_TOKEN` — the PAT from step 1.
+3. Tag and push the next release. The pipeline will detect both
+   secrets and push to docker.io alongside ghcr.io.
+
+**ECR Public with OIDC** (publishes to
+`public.ecr.aws/airvzxf/ftp-deployment-action` — no static AWS
+secrets):
+
+1. Create an ECR Public repository in the AWS account you want
+   to publish from. The repository's **alias** must be `airvzxf`
+   (so the URL is `public.ecr.aws/airvzxf/ftp-deployment-action`).
+   Aliases are globally unique within ECR Public; pick one you own.
+2. Create an IAM role with the following trust policy
+   (replace `ACCOUNT_ID` with your 12-digit AWS account ID):
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+         },
+         "Action": "sts:AssumeRoleWithWebIdentity",
+         "Condition": {
+           "StringEquals": {
+             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+           },
+           "StringLike": {
+             "token.actions.githubusercontent.com:sub": "repo:airvzxf/ftp-deployment-action:ref:refs/tags/v*"
+           }
+         }
+       }
+     ]
+   }
+   ```
+
+   The `sub` condition pins the role to *tag pushes only* of this
+   repo — pull requests and `workflow_dispatch` runs from forks
+   cannot assume it.
+
+3. Attach an inline policy granting the minimum ECR Public perms:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "ecr-public:GetAuthorizationToken"
+         ],
+         "Resource": "*"
+       },
+       {
+         "Effect": "Allow",
+         "Action": [
+           "ecr-public:BatchCheckLayerAvailability",
+           "ecr-public:PutImage",
+           "ecr-public:InitiateLayerUpload",
+           "ecr-public:UploadLayerPart",
+           "ecr-public:CompleteLayerUpload"
+         ],
+         "Resource": "arn:aws:ecr-public::ACCOUNT_ID:repository/airvzxf/ftp-deployment-action"
+       }
+     ]
+   }
+   ```
+
+4. Add one repository secret:
+   `AWS_ROLE_TO_ASSUME` — the role ARN from step 2
+   (e.g. `arn:aws:iam::ACCOUNT_ID:role/ftp-deployment-action-publisher`).
+5. Tag and push the next release. The pipeline will assume the
+   role via OIDC (`aws-actions/configure-aws-credentials@v4`)
+   and login with `aws-actions/amazon-ecr-login@v2`. No static
+   AWS access keys are stored in the repo.
+
+**Skipping a registry**: leave its secrets unset. The pipeline
+emits a `::notice::` and falls back to the registries that *do*
+have secrets configured. The ghcr.io path is unaffected.
+
 ## Settings
 
 Usually the zero values mean unlimited or infinite. This table is based on the default values on `lftp-4.9.2`.


### PR DESCRIPTION
Closes #87

LP-7 from the long-term roadmap. Every signed tag now publishes to **three** OCI registries (ghcr.io is unconditional; Docker Hub and ECR Public are conditional on repo secrets).

### Why

Discoverability and supply-chain flexibility. Users on AWS can pull from `public.ecr.aws` without leaving their account; users on traditional Docker tooling can pull from `docker.io`; ghcr.io remains the default for `uses: airvzxf/ftp-deployment-action@v2`. The three registries receive the **same** OCI image bytes (one `docker buildx build`, identical digest), the **same** cosign keyless signature, and the **same** CycloneDX SBOM attestation attached via `actions/attest`.

### What

- **`release.yml`** — the meta step now resolves `all_tags`, `dockerhub_enabled`, and `ecr_enabled` outputs based on the presence of `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` and `AWS_ROLE_TO_ASSUME` secrets. Cosign `sign` and `actions/attest` are invoked once per enabled registry. The smoke test still pulls only from ghcr.io (one OCI manifest, three registries — a ghcr.io failure implies the same elsewhere, so triple-pulling would triple latency for zero added coverage).
- **`release.yml`** — Docker Hub login via `docker/login-action@v4`; ECR Public login via `aws-actions/configure-aws-credentials@v4` (OIDC role assumption) + `aws-actions/amazon-ecr-login@v2`. **No static AWS secrets are stored**, only `AWS_ROLE_TO_ASSUME` holds a role ARN.
- **`README.md`** — new `Publishing targets` section listing the three registries with example `uses:` lines for each, plus a `Maintainer setup` subsection with copy-pasteable IAM trust policy JSON (`sub: repo:airvzxf/ftp-deployment-action:ref:refs/tags/v*` so only signed-tag pushes can assume the role) and the minimum ECR Public permission set.
- **`CHANGELOG.md`** — stamps the previous `[Unreleased]` block as `[2.9.0] - 2026-07-08` (it was left in `[Unreleased]` by PR #86 by mistake, which would have skipped it in the awk extractor at the next release). Adds a new `[Unreleased]` block for v2.10.0 with the LP-7 entry, and the `[2.9.0]` compare-link.

### Backward compat

If neither Docker Hub secrets nor `AWS_ROLE_TO_ASSUME` are set, the pipeline emits a `::notice::` for each skipped registry and publishes to ghcr.io only — **bit-for-bit identical to v2.9.0**.

### Validation

- `make shellcheck` — clean
- `make contract` — 31/31 inputs match (no input churn)
- `make unit` — 134/134 bats pass
- `make smoke` — 32/32 pass
- `make build VERSION=test` + `make release-smoke` — 3/3 pass
- `actionlint -color .github/workflows/release.yml` — clean
- YAML parse with PyYAML — 18 steps in expected order

### Manual setup needed after merge

Before tagging v2.10.0, the maintainer needs to:
1. Create a Docker Hub PAT and add `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` to the repo secrets (optional).
2. Create an ECR Public repository (`airvzxf/ftp-deployment-action`) and an IAM role with the trust policy from README (optional).
3. Add the role ARN as `AWS_ROLE_TO_ASSUME` (optional).

All three steps are optional — the v2.9.0 behaviour (ghcr.io only) is preserved without them.

Refs: PROPOSAL.md LP-7, ROADMAP.md §7 `Roadmap lejano`.