### PR TITLE
fix(release): emit all_tags with per-line echo so GitHub's heredoc EOF lands on its own line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
           # ghcr.io is always published (GITHUB_TOKEN is automatic).
           tags="${image}:${version}"$'\n'"${image}:${tag}"$'\n'"${image}:latest"
 
+          dockerhub_image=""
+          ecr_image=""
+
           if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
             dockerhub_image="docker.io/airvzxf/ftp-deployment-action"
             tags="${tags}"$'\n'"${dockerhub_image}:${version}"$'\n'"${dockerhub_image}:${tag}"$'\n'"${dockerhub_image}:latest"
@@ -95,12 +98,29 @@ jobs:
             echo "::notice::AWS_ROLE_TO_ASSUME secret not set; skipping public.ecr.aws publish"
           fi
 
-          # Heredoc-style multi-line output for `all_tags`. The
-          # build-push step consumes it as a YAML block scalar;
-          # the trailing newline is stripped by the consumer.
+          # Heredoc-style multi-line output for `all_tags`. Each tag
+          # is written on its own line with `echo` so the EOF
+          # delimiter lands on its own line — `printf '%s'` would
+          # glue the last tag to the EOF marker and trip GitHub's
+          # output parser with "Matching delimiter not found 'EOF'".
+          # This per-line shape also guarantees no trailing newline
+          # on the last tag, which would otherwise produce a spurious
+          # empty tag in docker/build-push-action.
           {
             echo "all_tags<<EOF"
-            printf '%s' "${tags}"
+            echo "${image}:${version}"
+            echo "${image}:${tag}"
+            echo "${image}:latest"
+            if [ -n "${dockerhub_image}" ]; then
+              echo "${dockerhub_image}:${version}"
+              echo "${dockerhub_image}:${tag}"
+              echo "${dockerhub_image}:latest"
+            fi
+            if [ -n "${ecr_image}" ]; then
+              echo "${ecr_image}:${version}"
+              echo "${ecr_image}:${tag}"
+              echo "${ecr_image}:latest"
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Closes #89

Hotfix following PR #88 (LP-7 multi-registry publishing). Caught by running the release pipeline via `workflow_dispatch` with v2.9.0 as the version, with all three secrets configured.

### Symptom

`Resolve tag, version and enabled registries` crashed with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found 'EOF'
```

(Run 28964775400, caught immediately because LP-7 enables the multi-registry code path that the previous tag-based releases never exercised — every previous release had only ghcr.io configured, so the bug was latent.)

### Root cause

`meta` step emitted the `all_tags<<EOF` multi-line output via `printf '%s'`, which does **not** emit a trailing newline. So the file became:

```
all_tags<<EOF
ghcr.io/airvzxf/ftp-deployment-action:2.9.0
...
public.ecr.aws/airvzxf/ftp-deployment-action:latestEOF
<EOL>
```

The EOF delimiter was glued to the last tag, no LF separator. GitHub's output parser looks for EOF at start-of-line and fails.

### Fix

Emit each tag on its own line with `echo` (not `printf '%s'`). Side benefit: no trailing newline on the last tag, which would otherwise produce a spurious empty final entry in `docker/build-push-action` when it splits `tags:` by newline.

### Backward compat

ghcr.io-only behaviour (no DOCKERHUB_*/AWS_ROLE_TO_ASSUME secrets) is unchanged — the per-line echoes for the secondary registries are gated on the same conditionals as before.

### Validation

- YAML parse with PyYAML: 18 steps in expected order
- make shellcheck: clean
- actionlint: clean
- Workflow re-run after merge: will be the actual end-to-end test

Refs: PR #88 follow-up, run 28964775400.