### PR TITLE
fix(release): use the actual ECR Public registry ID m2z1h0m9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           fi
 
           if [ -n "${AWS_ROLE_TO_ASSUME}" ]; then
-            ecr_image="public.ecr.aws/airvzxf/ftp-deployment-action"
+            ecr_image="public.ecr.aws/m2z1h0m9/ftp-deployment-action"
             tags="${tags}"$'\n'"${ecr_image}:${version}"$'\n'"${ecr_image}:${tag}"$'\n'"${ecr_image}:latest"
             {
               echo "ecr_image=${ecr_image}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [2.10.0] - 2026-07-08
+
 ### Added
 
 - **Multi-registry publishing for releases (LP-7)**. Every tag is
@@ -643,6 +646,7 @@ Four PRs on top of v2.1.0. No breaking change.
 [2.0.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.5.0
 [2.9.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.8.0...v2.9.0
+[2.10.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.9.0...v2.10.0
 [1.3.3]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.3.3
 
 ## [2.1.0] - 2026-07-05
@@ -849,5 +853,6 @@ Historical. See git history for changes prior to `CHANGELOG.md` adoption.
 [2.0.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.5.0
 [2.9.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.8.0...v2.9.0
+[2.10.0]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.9.0...v2.10.0
 [2.4.1]: https://github.com/airvzxf/ftp-deployment-action/compare/v2.4.0...v2.4.1
 [1.3.3]: https://github.com/airvzxf/ftp-deployment-action/releases/tag/v1.3.3

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pick whichever is closest (or already trusted) in their supply chain:
 |---|---|---|
 | GitHub Container Registry (default) | `ghcr.io/airvzxf/ftp-deployment-action:v2.10.0` | `uses: airvzxf/ftp-deployment-action@v2` (the example above) |
 | Docker Hub | `docker.io/airvzxf/ftp-deployment-action:v2.10.0` | `uses: docker://docker.io/airvzxf/ftp-deployment-action@v2` |
-| AWS ECR Public | `public.ecr.aws/airvzxf/ftp-deployment-action:v2.10.0` | `uses: docker://public.ecr.aws/airvzxf/ftp-deployment-action@v2` |
+| AWS ECR Public | `public.ecr.aws/m2z1h0m9/ftp-deployment-action:v2.10.0` | `uses: docker://public.ecr.aws/m2z1h0m9/ftp-deployment-action@v2` |
 
 All three carry the same OCI image bytes (one `docker buildx build`,
 one digest), the same `cosign` keyless signature
@@ -132,13 +132,16 @@ maintainer pushing new releases.
    secrets and push to docker.io alongside ghcr.io.
 
 **ECR Public with OIDC** (publishes to
-`public.ecr.aws/airvzxf/ftp-deployment-action` — no static AWS
+`public.ecr.aws/m2z1h0m9/ftp-deployment-action` — no static AWS
 secrets):
 
 1. Create an ECR Public repository in the AWS account you want
-   to publish from. The repository's **alias** must be `airvzxf`
-   (so the URL is `public.ecr.aws/airvzxf/ftp-deployment-action`).
-   Aliases are globally unique within ECR Public; pick one you own.
+   to publish from. The repository name must be `ftp-deployment-action`
+   (the URL becomes `public.ecr.aws/<registry-id>/ftp-deployment-action`,
+   where `<registry-id>` is the account-specific registry ID AWS
+   assigns automatically — e.g. `m2z1h0m9` for this account). AWS
+   does **not** let you set a custom registry ID: it is derived from
+   your AWS Account ID and is permanent for the account.
 2. Create an IAM role with the following trust policy
    (replace `ACCOUNT_ID` with your 12-digit AWS account ID):
 
@@ -191,7 +194,7 @@ secrets):
            "ecr-public:UploadLayerPart",
            "ecr-public:CompleteLayerUpload"
          ],
-         "Resource": "arn:aws:ecr-public::ACCOUNT_ID:repository/airvzxf/ftp-deployment-action"
+         "Resource": "arn:aws:ecr-public::ACCOUNT_ID:repository/m2z1h0m9/ftp-deployment-action"
        }
      ]
    }


### PR DESCRIPTION
Closes #91

AWS ECR Public deprecated user-settable registry aliases in 2023-2024. New accounts (and accounts that never set a custom alias) get an auto-generated, immutable registry ID derived from the AWS Account ID. For airvzxf/ftp-deployment-action's account, that ID is `m2z1h0m9`.

### Symptom (from the v2.10.0 test run)

```
failed to push public.ecr.aws/airvzxf/ftp-deployment-action:2.10.0:
unknown: The repository with name 'ftp-deployment-action' does not exist in the registry with id 'airvzxf'
```

ghcr.io and Docker Hub published successfully; only ECR Public failed.

### Fix

- `release.yml`: `ecr_image` is now `public.ecr.aws/m2z1h0m9/ftp-deployment-action` (matching the actual repo URI; the redundant `airvzxf/` namespace prefix was removed from the repo name when recreating it cleanly).
- `README.md`: table row, Maintainer setup section, and IAM policy ARN example all reflect the new URL. Setup instructions now explain that the registry ID is permanent and account-specific (no longer user-settable).

### Validation

- YAML parse: valid
- make shellcheck: clean
- actionlint: clean
- End-to-end test (re-tag v2.10.0 after merge): publishes to all three registries

Refs: PR #88 (LP-7), PR #90 (heredoc EOF fix), v2.10.0 tag push (test)