### PR TITLE
ci(workflow): pin aws-actions/* + update softprops/action-gh-release to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
       # README section "Publishing targets" for the JSON).
       - name: Configure AWS credentials (OIDC) for ECR Public
         if: ${{ steps.meta.outputs.ecr_enabled == 'true' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           # ECR Public control plane lives in us-east-1 regardless
@@ -181,7 +181,7 @@ jobs:
 
       - name: Log in to ECR Public
         if: ${{ steps.meta.outputs.ecr_enabled == 'true' }}
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@b040164c4934333d597f3f9c67502ff28f814e9c # v2.1.6
         with:
           registry-type: public
 
@@ -358,7 +358,7 @@ jobs:
       # `generate_release_notes` builds the body from the tag
       # delta as a fallback.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@2bb465e97f322d3cb2a965294d483e0d26a67aa9 # v3.0.1
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
Closes #93

Three actions in `.github/workflows/release.yml` were either un-pinned (floating tag) or on an old SHA, causing the persistent `Node.js 20 is deprecated` warning visible in every release pipeline run.

### What

- **`aws-actions/configure-aws-credentials`**: was `@v4` (floating). Now pinned to **v6.2.2** (`517a711dbcd0e402f90c77e7e2f81e849156e31d`). v6 targets Node 24, removing the deprecation warning.
- **`aws-actions/amazon-ecr-login`**: was `@v2` (floating). Now pinned to **v2.1.6** (`b040164c4934333d597f3f9c67502ff28f814e9c`).
- **`softprops/action-gh-release`**: was on an old SHA (`718ea10b…`) — same v3.0.1 version, but the maintainer updated the tag's commit object since. New SHA: `2bb465e97f322d3cb2a965294d483e0d26a67aa9`.

### Audit of all other actions

All other actions in release.yml and ci.yml were already at their latest SHA-pinned versions — no change needed:

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v7.0.0 | `9c091bb2` |
| `docker/setup-buildx-action` | v4.2.0 | `bb05f3f5` |
| `docker/login-action` | v4.4.0 | `af1e73f9` |
| `docker/build-push-action` | v7.3.0 | `53b7df96` |
| `anchore/sbom-action` | v0.24.0 | `e22c3899` |
| `actions/download-artifact` | v8.0.1 | `3e5f45b2` |
| `sigstore/cosign-installer` | v4.1.2 | `6f9f1778` |
| `actions/attest` | v4.1.1 | `a1948c3f` |
| `hadolint/hadolint-action` | v3.3.0 | `2332a7b7` (ci.yml) |

### Backward compat

None — all three actions preserve their input/output contracts.

### Validation

- YAML parse: valid
- actionlint: clean
- make shellcheck: clean (no shell changes)

### No new tag

This is a maintenance PR, not a feature. The next release tag will run against the pinned actions and the deprecation warning will be gone.

Refs: run 28968978106, runs after this should show no Node.js 20 warning.