### PR TITLE
fix(workflow): use commit SHAs (not tag-object SHAs) for action pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Log in to ECR Public
         if: ${{ steps.meta.outputs.ecr_enabled == 'true' }}
-        uses: aws-actions/amazon-ecr-login@b040164c4934333d597f3f9c67502ff28f814e9c # v2.1.6
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
         with:
           registry-type: public
 
@@ -358,7 +358,7 @@ jobs:
       # `generate_release_notes` builds the body from the tag
       # delta as a fallback.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@2bb465e97f322d3cb2a965294d483e0d26a67aa9 # v3.0.1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
Follow-up to PR #94. Two of the three SHAs introduced there were actually the SHA of the *annotated tag object*, not the SHA of the commit the tag points to.

### Why this matters

GitHub Actions dereferences annotated tags at runtime, so the v2.10.0 publish succeeded even with the wrong SHAs. But the project convention is to pin to the **commit SHA** — that's what the GitHub UI tag page shows, what `actions/<name>@<sha>` checksums compute, and what Dependabot updates check against. Using tag-object SHAs is exactly the kind of subtle drift Dependabot's `unpinned` alerts are designed to catch.

### Caught by

The maintainer, who manually reviewed the GitHub tags page for softprops/action-gh-release and noted that v3.0.1's SHA is `718ea10` (3 weeks ago), not the `2bb4659` I introduced.

### Fix

| Action | Tag | Was | Now |
|---|---|---|---|
| `softprops/action-gh-release` | v3.0.1 | `2bb4659…` (tag object) | `718ea10b…` (commit, what the GitHub UI shows) |
| `aws-actions/amazon-ecr-login` | v2.1.6 | `b040164c…` (tag object) | `d539f0932…` (commit, same SHA GitHub Actions resolved in run logs) |

### Audit of every other pinned action (10/12 already correct)

10 of the 12 actions pinned across `.github/workflows/release.yml` and `.github/workflows/ci.yml` are lightweight tags, so their tag SHA IS the commit SHA — no change needed: actions/checkout, docker/setup-buildx-action, docker/login-action, docker/build-push-action, anchore/sbom-action, actions/download-artifact, sigstore/cosign-installer, actions/attest, hadolint/hadolint-action, aws-actions/configure-aws-credentials.

The other 2 (the ones in this PR) are annotated tags where the tag-object SHA differs from the commit SHA.

### Validation

- YAML parse: valid
- actionlint: clean
- make shellcheck: clean

Refs: PR #94, run 28968978106.