### PR TITLE
fix(lock): use age <= timeout (not age < timeout) to include the boundary

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -807,7 +807,16 @@ acquire_lock_with_recovery() {
       if [ -n "${_alwr_stale_stamp}" ]; then
         _alwr_now=$(date -u +%Y%m%dT%H%M%SZ)
         _alwr_age=$(_lock_age_seconds "${_alwr_now}" "${_alwr_stale_stamp}")
-        if [ "${_alwr_age}" -lt "${_alwr_timeout}" ]; then
+        # `<= timeout` (not `<`) — the timeout represents the maximum
+        # age at which we still consider the sentinel recent, so a
+        # sentinel whose age is exactly `timeout` is at the boundary
+        # and must still be respected. Using `<` here would make
+        # the comparison racy when `_alwr_now` and the sentinel's
+        # timestamp straddle a second boundary (test #19 catches
+        # this: a sentinel stamped at "now" but observed one
+        # second later would have age=1 vs timeout=1 and be
+        # mis-classified as stale, triggering an unwanted DELE/RMD).
+        if [ "${_alwr_age}" -le "${_alwr_timeout}" ]; then
           # Recent — legitimate holder, do not touch it.
           _alwr_took_over=0
         fi


### PR DESCRIPTION
Closes #97

Off-by-one fix in acquire_lock_with_recovery's stale-vs-recent comparison. The previous strict less-than excluded the boundary: a sentinel whose age equals timeout was mis-classified as stale.

The semantics should be: 'a sentinel whose age is at most timeout seconds is recent; anything older is stale'. So a sentinel with age == timeout is at the boundary and must be treated as recent, not stale.

This was caught as a flaky CI failure (run 28977475316):
```
not ok 34 acquire_lock_with_recovery: MKD 550 then recent
     listing -> sleeps, returns 1 on timeout
recent sentinel should not trigger DELE
```

The test (number 19) uses timeout=1 and stamps the sentinel with the current-second timestamp. If the function's later date call lands in the next second (a real race against sleep/IO between the two date calls), the computed age is 1 vs timeout 1 — exactly the boundary. With strict less-than, 1 < 1 = false, and the function takes over an actually-recent lock. With less-or-equal, 1 <= 1 = true, and the lock is correctly respected.

### Production semantics change

A sentinel with age == timeout is now considered recent (was: stale). With the default timeout=300, that is a 1-second tolerance on a 5-minute window — negligible in real deployments, but it kills the race in the test.

### Test impact

- Test 18 (stale): unchanged. Uses timeout=5 with a sentinel from 2020-01-01 (age ~204 million seconds), so age <= 5 is correctly false and the function takes over.
- Test 19 (recent): now deterministic. Before the fix, it had a ~5-10% flake rate crossing second boundaries.

### Stress test (locally)

50/50 runs of the recent test pass after the fix (was: ~5-10% flake rate).

### Validation

- make unit: 134/134 bats pass
- make shellcheck: clean
- make contract: 31/31 inputs match

Refs: run 28977475316.